### PR TITLE
Removes the big white space in the middle of the release notes page.

### DIFF
--- a/template/release-notes.html
+++ b/template/release-notes.html
@@ -46,10 +46,6 @@
     </aside>
   </section>
 
-  <section class="pt-20 pb-16 w-full bg-calendar -mt-10">
-    &nbsp;
-  </section>
-
   {% if notes %}
     <section class="pb-10 flex flex-wrap justify-center items-center pl-8 pr-8 bg-grey-lighter">
       <aside class="flex flex-col w-full max-w-6xl lg:ml-16 lg:mr-16">


### PR DESCRIPTION
Someone brought up the big white space in the middle of the release notes pages in chat a few weeks ago. This just removes that space.

**Current**
![release_notes_pre](https://user-images.githubusercontent.com/106888/81314508-34c37280-9057-11ea-943a-e99c3ba28796.png)

**Post Changes**
![release_notes_post](https://user-images.githubusercontent.com/106888/81314506-342adc00-9057-11ea-9bd4-fe12ce2952d8.png)

