### PR TITLE
Bug lists conversion work

### DIFF
--- a/archive/57.0beta.yml
+++ b/archive/57.0beta.yml
@@ -1,59 +1,71 @@
 release:
   release_date: 2017-11-10
-  text: "**These release notes apply to Thunderbird version 57 beta 2 released November 20th, 2017.**"
+  text: "**These release notes apply to Thunderbird version 57 beta 2 released November\
+    \ 20th, 2017.**"
   bug_search_url: https://bugzilla.mozilla.org/buglist.cgi?classification=Client%20Software&query_format=advanced&bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&target_milestone=Thunderbird%2057.0&product=Thunderbird&resolution=FIXED
   import_system_requirements: '53.0beta'
 notes:
 - note: Allow changing the Spellcheck Language from status bar display
   tag: new
-  bug: 1399370
+  bugs:
+  - 1399370
 - note: '"New Message from Template" command'
   tag: new
-  bug: 1389083
-- note: '"Edit As New Message" will now use the account''s default compose format,
-    either HTML or plain text ignoring the format of the message. Plain text messages
-    will be converted to HTML and vice versa. Then using the modifier, the format
-    choice will be reverted.'
+  bugs:
+  - 1389083
+- note: '"Edit As New Message" will now use the account''s default compose format, either
+    HTML or plain text ignoring the format of the message. Plain text messages will be
+    converted to HTML and vice versa. Then using the modifier, the format choice will be
+    reverted.'
   tag: changed
-  bug: 731688
-- note: The plain text to HTML conversion has been improved where such a conversion
-    is necessary for "Edit As New Message" or when the shift modifier is used for
-    "Edit Draft" or "New Message from Template".
+  bugs:
+  - 731688
+- note: The plain text to HTML conversion has been improved where such a conversion is
+    necessary for "Edit As New Message" or when the shift modifier is used for "Edit Draft"
+    or "New Message from Template".
   tag: changed
-  bug: 1392052
-- note: The "Edit Draft" command now also honors the use of the shift key to convert
-    HTML to plain text or vice versa when editing a draft
+  bugs:
+  - 1392052
+- note: The "Edit Draft" command now also honors the use of the shift key to convert HTML
+    to plain text or vice versa when editing a draft
   tag: changed
-  bug: 1389771
-- note: When attaching a message via drag and drop, the subject of the message is
-    now used as attachment name instead of "Attached Message"
+  bugs:
+  - 1389771
+- note: When attaching a message via drag and drop, the subject of the message is now used
+    as attachment name instead of "Attached Message"
   tag: changed
-  bug: 209629
-- note: On first start, Thunderbird now shows the account setup dialog, no longer
-    the account provisioner dialog
+  bugs:
+  - 209629
+- note: On first start, Thunderbird now shows the account setup dialog, no longer the account
+    provisioner dialog
   tag: changed
-  bug: 1349259
-- note: Thunderbird follows Firefox' Photon design with rectangular tabs and many
-    other theme improvements
+  bugs:
+  - 1349259
+- note: Thunderbird follows Firefox' Photon design with rectangular tabs and many other
+    theme improvements
   tag: changed
-  bug: 1387877
-- note: In Thunderbird 54 beta a better support for Charter users was introduced.
-    As a side effect, messages moved to a different IMAP folder were immediately removed
-    from the source folder, even when the delete model "Just mark it as deleted" was
-    in effect. This has now been restored to its pre-version 54 state, so moved IMAP
-    messages are only crossed out in the source folder when this delete model is used.
+  bugs:
+  - 1387877
+- note: In Thunderbird 54 beta a better support for Charter users was introduced. As a
+    side effect, messages moved to a different IMAP folder were immediately removed from
+    the source folder, even when the delete model "Just mark it as deleted" was in effect.
+    This has now been restored to its pre-version 54 state, so moved IMAP messages are
+    only crossed out in the source folder when this delete model is used.
   tag: changed
-  bug: 1352859
-- note: 'When many Thunderbird clients or other email clients accessed the same IMAP
-    draft folder, messages were sometimes sent with the wrong identity. This has been
-    corrected and the user will be notified if none of their identities matches the
-    draft. '
+  bugs:
+  - 1352859
+- note: 'When many Thunderbird clients or other email clients accessed the same IMAP draft
+    folder, messages were sometimes sent with the wrong identity. This has been corrected
+    and the user will be notified if none of their identities matches the draft. '
   tag: fixed
-  bug: 394216
+  bugs:
+  - 394216
 - note: "Passwords can now contain non-ASCII characters, like international characters,\
-    \ for example \xE1\xE4\xDF, and symbols, for example \u20AC\xA7"
+    \ for example áäß, and symbols, for example €§"
   tag: fixed
-  bug: 312593
+  bugs:
+  - 312593
 - note: Certain add-ons would cause Thunderbird not to start
   tag: fixed
-  bug: 1417209
+  bugs:
+  - 1417209

--- a/archive/58.0beta.yml
+++ b/archive/58.0beta.yml
@@ -1,30 +1,38 @@
 release:
   release_date: 2017-11-27
-  text: "**These release notes apply to Thunderbird version 58 beta 2 released December 10th, 2017.**"
+  text: "**These release notes apply to Thunderbird version 58 beta 2 released December\
+    \ 10th, 2017.**"
   bug_search_url: https://bugzilla.mozilla.org/buglist.cgi?classification=Client%20Software&query_format=advanced&bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&target_milestone=Thunderbird%2058.0&product=Thunderbird&resolution=FIXED
   import_system_requirements: '53.0beta'
 notes:
 - note: When composing a message, attachments can now be reordered
   tag: new
-  bug: 663695
+  bugs:
+  - 663695
 - note: Thunderbird Chat now contains multiple built-in message themes
   tag: new
-  bug: 1409839
+  bugs:
+  - 1409839
 - note: 'Thunderbird Chat: Nicknames inside of messages are colored to match the participants
     list'
   tag: changed
-  bug: 1409901
+  bugs:
+  - 1409901
 - note: Better error handling for Yahoo accounts
   tag: fixed
-  bug: 1408610
+  bugs:
+  - 1408610
 - note: Outlook import
   tag: fixed
-  bug: 1176748
+  bugs:
+  - 1176748
 - note: Performance problem when repairing, rebuilding or compacting folders or accessing
     large folders
   tag: fixed
-  bug: 1415723
+  bugs:
+  - 1415723
 - note: 'Localised versions of Thunderbird didn''t show a localised name for Hotmail''s
     "Deleted" folder '
   tag: fixed
-  bug: 1320191
+  bugs:
+  - 1320191

--- a/archive/59.0beta.yml
+++ b/archive/59.0beta.yml
@@ -1,60 +1,74 @@
 release:
   release_date: 2018-03-01
-  text: "**These release notes apply to Thunderbird version 59 beta 2 released March 1st, 2018. **"
+  text: "**These release notes apply to Thunderbird version 59 beta 2 released March 1st,\
+    \ 2018. **"
   bug_search_url: https://bugzilla.mozilla.org/buglist.cgi?classification=Client%20Software&query_format=advanced&bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&target_milestone=Thunderbird%2059.0&product=Thunderbird&resolution=FIXED
   import_system_requirements: '53.0beta'
 notes:
-- note: Further improvements to reordering attachments (introduced in Thunderbird
-    58 beta), including reordering by drag & drop
+- note: Further improvements to reordering attachments (introduced in Thunderbird 58 beta),
+    including reordering by drag & drop
   tag: new
-  bug: 229224
+  bugs:
+  - 229224
 - note: Edit Template command. This also solves various problems when saving as template
     (duplicates created, message ID lost).
   tag: new
-  bug: 1389062
+  bugs:
+  - 1389062
 - note: 'Calendar: Option to select the target calendar when pasting an event or task'
   tag: new
-  bug: 719351
-- note: Add-on options can no longer be configured from the Add-on Manager page. A
-    new menu item "Add-on Options" is now available on the Tools menu.
+  bugs:
+  - 719351
+- note: Add-on options can no longer be configured from the Add-on Manager page. A new
+    menu item "Add-on Options" is now available on the Tools menu.
   tag: changed
-  bug: 1419145
-- note: 'When customizing the From: address, Thunderbird will now use this address
-    for the SMTP "MAIL FROM" command. Previously the address configured in the identity
-    was used. The preference mail.smtp.useSenderForSmtpMailFrom allows return to the
-    previous behavior.'
+  bugs:
+  - 1419145
+- note: 'When customizing the From: address, Thunderbird will now use this address for
+    the SMTP "MAIL FROM" command. Previously the address configured in the identity was
+    used. The preference mail.smtp.useSenderForSmtpMailFrom allows return to the previous
+    behavior.'
   tag: changed
-  bug: 1294027
+  bugs:
+  - 1294027
 - note: Various updates to the Thunderbird theme. Thunderbird now uses <a href="https://design.firefox.com/icons/viewer/">Photon
     Icons</a>.
   tag: changed
-  bug: 1427509
+  bugs:
+  - 1427509
 - note: 'Calendar: Reminders on read-only calendars can now be dismissed, while reminders
-    for missed events will now only be displayed for writable calendars if option
-    "Show missed reminders for writable calendars" is selected'
+    for missed events will now only be displayed for writable calendars if option "Show
+    missed reminders for writable calendars" is selected'
   tag: changed
-  bug: 356002
-- note: 'Various problems related to handling the IMAP trash folder: Under certain
-    circumstances the selection of the trash folder didn''t persist, for example when
-    the name contained non-ASCII characters, or in localized versions of Thunderbird.
-    At times unwanted additional trash folders were created. Selection of a trash
-    folder didn''t give immediate visual feedback.'
+  bugs:
+  - 356002
+- note: 'Various problems related to handling the IMAP trash folder: Under certain circumstances
+    the selection of the trash folder didn''t persist, for example when the name contained
+    non-ASCII characters, or in localized versions of Thunderbird. At times unwanted additional
+    trash folders were created. Selection of a trash folder didn''t give immediate visual
+    feedback.'
   tag: fixed
-  bug: 1335982
-- note: Searching message bodies of messages in local folders, including filter and
-    quick filter operations, did not find content in message attachments
+  bugs:
+  - 1335982
+- note: Searching message bodies of messages in local folders, including filter and quick
+    filter operations, did not find content in message attachments
   tag: fixed
-  bug: 1434020
+  bugs:
+  - 1434020
 - note: Shared IMAP folders not shown in subscribe dialog under some circumstances
   tag: fixed
-  bug: 1419735
+  bugs:
+  - 1419735
 - note: Improvements encoding/decoding message headers
   tag: fixed
-  bug: 1437282
+  bugs:
+  - 1437282
 - note: 'Calendar: Wrong time formatting for some time zones'
   tag: fixed
-  bug: 1396639
+  bugs:
+  - 1396639
 - note: The IMAP and News subscribe dialogue now presents a flat list of folders instead
     of a folder tree. This will be restored to its original form in the next release.
   tag: unresolved
-  bug: 1425962
+  bugs:
+  - 1425962

--- a/beta/60.0beta.yml
+++ b/beta/60.0beta.yml
@@ -1,12 +1,12 @@
 release:
   release_date: 2018-03-26
-  text: "**These release notes apply to Thunderbird version 60 beta 11 released September 4th, 2018.**
-    Thunderbird 60.0 beta 11 is shipping changes destined for TB 60.1 ESR.
-    For technical reasons it is not called Thunderbird 60.1 beta 1.
-    **If you have installed Lightning, Thunderbird's Calendar add-on, it may not automatically
-    be updated from a previous version of Thunderbird 60 beta.** Refer to this
-    [Calendar troubleshooting article](https://support.mozilla.org/en-US/kb/calendar-updates-issues-thunderbird)
-    (last section \"..., Lightning is not updated\") in case of problems."
+  text: "**These release notes apply to Thunderbird version 60 beta 11 released September\
+    \ 4th, 2018.** Thunderbird 60.0 beta 11 is shipping changes destined for TB 60.1 ESR.\
+    \ For technical reasons it is not called Thunderbird 60.1 beta 1. **If you have installed\
+    \ Lightning, Thunderbird's Calendar add-on, it may not automatically be updated from\
+    \ a previous version of Thunderbird 60 beta.** Refer to this [Calendar troubleshooting\
+    \ article](https://support.mozilla.org/en-US/kb/calendar-updates-issues-thunderbird)\
+    \ (last section \"..., Lightning is not updated\") in case of problems."
   system_requirements: |
     ## Windows
 
@@ -62,183 +62,222 @@ release:
         - DBus 1.0 or higher
         - GNOME 2.16 or higher
   groups:
-    - "Fixed in Beta 11"
-    - "Fixed in Beta 10"
+  - "Fixed in Beta 11"
+  - "Fixed in Beta 10"
 
 notes:
 - note: 'OAuth2 authentication for Yahoo and AOL (already shipped in Thunderbird 60.0 ESR)'
   tag: new
-  bug: 1310384
-- note: 'Calendar: Default values for the first day of the week and working days
-    are now derived from the selected datetime formatting locale
-    (restart after changing locale in the OS required)'
+  bugs:
+  - 1310384
+- note: 'Calendar: Default values for the first day of the week and working days are now
+    derived from the selected datetime formatting locale (restart after changing locale
+    in the OS required)'
   tag: changed
-  bug: 1481790
+  bugs:
+  - 1481790
 - note: 'Calendar: Switch to a Photon-style icon set for all platforms'
   tag: changed
-  bug: 1446748
+  bugs:
+  - 1446748
 - note: 'Multiple requests for master password when Google Mail or Calendar OAuth2 is enabled'
   tag: fixed
-  bug: 1176399
-  bug2: 682474
-- note: 'Scrolling the address entry auto-complete popup with the mouse wheel does not work
-   (already shipped in Thunderbird 60.0 ESR)'
+  bugs:
+  - 1176399
+  - 682474
+- note: 'Scrolling the address entry auto-complete popup with the mouse wheel does not
+    work (already shipped in Thunderbird 60.0 ESR)'
   tag: fixed
-  bug: 1457085
+  bugs:
+  - 1457085
 - note: 'Scrollbar of the address entry auto-complete popup does not work'
   tag: fixed
-  bug: 1486178
+  bugs:
+  - 1486178
 - note: "Security info dialog in compose window does not show certificate status"
   tag: fixed
-  bug: 1293378
+  bugs:
+  - 1293378
 - note: 'Calendar: First day of the week cannot be set'
   tag: fixed
-  bug: 1473294
+  bugs:
+  - 1473294
 - note: 'Calendar: Several fixes related to cutting/deleting of events and email scheduling'
   tag: fixed
 # Beta 10 below here.
 - note: When writing a message, a delete button now allows the removal of a recipient.
     This delete button is displayed when hovering the To/Cc/Bcc selector.
   tag: new
-  bug: 1100103
+  bugs:
+  - 1100103
   group: 2
-- note: 'Further improvements to attachments handling during compose:
-    "Attach" button moved to the right to be above the attachment pane.
-    Alt+M now allows to show the attachment pane. The attachment pane can also be shown initially when
-    composing a new message. Right-click on the header to enable this option.
-    It is now also impossible to completely collapse a non-empty attachment pane.
-    That protects against attachments accidentally being sent.'
+- note: 'Further improvements to attachments handling during compose: "Attach" button moved
+    to the right to be above the attachment pane. Alt+M now allows to show the attachment
+    pane. The attachment pane can also be shown initially when composing a new message.
+    Right-click on the header to enable this option. It is now also impossible to completely
+    collapse a non-empty attachment pane. That protects against attachments accidentally
+    being sent.'
   tag: new
-  bug: 1428631
+  bugs:
+  - 1428631
   group: 2
-- note: 'Thunderbird now allows the conversion of folders from mbox to maildir format
-    and vice versa. This is an **experimental** feature that needs to be enabled by
-    setting the preference mail.store_conversion_enabled.
-    Note that this functionality does not not work if the option
-    "Allow Windows Search/Spotlight to search messages" is selected.'
+- note: 'Thunderbird now allows the conversion of folders from mbox to maildir format and
+    vice versa. This is an **experimental** feature that needs to be enabled by setting
+    the preference mail.store_conversion_enabled. Note that this functionality does not
+    not work if the option "Allow Windows Search/Spotlight to search messages" is selected.'
   tag: new
-  bug: 856087
+  bugs:
+  - 856087
   group: 2
 - note: Light and Dark themes
   tag: new
-  bug: 1456219
+  bugs:
+  - 1456219
   group: 2
 - note: WebExtension themes are now enabled in Thunderbird
   tag: new
-  bug: 1450670
+  bugs:
+  - 1450670
   group: 2
 - note: 'FIDO U2F support'
   tag: new
-  bug: 1444101
+  bugs:
+  - 1444101
   group: 2
-- note: 'Calendar: Allow copying, cutting or deleting of a selected occurrence or
-    the entire series for recurring events'
+- note: 'Calendar: Allow copying, cutting or deleting of a selected occurrence or the entire
+    series for recurring events'
   tag: new
-  bug: 393084
+  bugs:
+  - 393084
   group: 2
-- note: 'Calendar: Provide an option to display locations for events in calendar day
-    and week views'
+- note: 'Calendar: Provide an option to display locations for events in calendar day and
+    week views'
   tag: new
-  bug: 321434
+  bugs:
+  - 321434
   group: 2
-- note: 'Calendar: Provide the ability for sending/not sending meeting notifications
-    directly instead of showing a popup'
+- note: 'Calendar: Provide the ability for sending/not sending meeting notifications directly
+    instead of showing a popup'
   tag: new
-  bug: 463402
+  bugs:
+  - 463402
   group: 2
-- note: "**IMPORTANT:** Add-ons not marked as compatible with Thunderbird 60 by their
-    authors will be disabled (this can be reverted via preference extensions.strictCompatibility)"
+- note: "**IMPORTANT:** Add-ons not marked as compatible with Thunderbird 60 by their authors\
+    \ will be disabled (this can be reverted via preference extensions.strictCompatibility)"
   tag: changed
-  bug: 1451097
+  bugs:
+  - 1451097
   group: 2
-- note: 'Thunderbird will now prompt to compact IMAP folders even if the account is
-    online. Note: Under certain circumstances an incorrect estimate of the expected gain is shown.'
+- note: 'Thunderbird will now prompt to compact IMAP folders even if the account is online.
+    Note: Under certain circumstances an incorrect estimate of the expected gain is shown.'
   tag: changed
-  bug: 1157256
+  bugs:
+  - 1157256
   group: 2
-- note: 'Better address book photo handling: Photos can be added by drag and drop and
-    a copy of all photos will be stored in the Thunderbird profile'
+- note: 'Better address book photo handling: Photos can be added by drag and drop and a
+    copy of all photos will be stored in the Thunderbird profile'
   tag: changed
-  bug: 892889
+  bugs:
+  - 892889
   group: 2
 - note: Native notifications on Linux are now re-enabled
   tag: changed
-  bug: 1358837
+  bugs:
+  - 1358837
   group: 2
-- note: During address entry, the matching part of the address is now shown in bold.
-    Preference mail.autoComplete.commentColumn allows to display the address book
-    where the address is stored.
+- note: During address entry, the matching part of the address is now shown in bold. Preference
+    mail.autoComplete.commentColumn allows to display the address book where the address
+    is stored.
   tag: changed
-  bug: 1436290
+  bugs:
+  - 1436290
   group: 2
 - note: 'Calendar: Removal of capability to send email invitations compatible to Outlook
     2002 and earlier'
   tag: changed
-  bug: 463402
+  bugs:
+  - 463402
   group: 2
-- note: 'Various problems when forwarding messages inline: Some introduced in Thunderbird 60 beta 7,
-    some dating back to 2005 when using "simple" HTML view.'
+- note: 'Various problems when forwarding messages inline: Some introduced in Thunderbird
+    60 beta 7, some dating back to 2005 when using "simple" HTML view.'
   tag: fixed
-  bug: 394322
+  bugs:
+  - 394322
   group: 2
-- note: The IMAP and News subscribe dialog did not present a folder tree
-    (not working since Thunderbird version 59)
+- note: The IMAP and News subscribe dialog did not present a folder tree (not working since
+    Thunderbird version 59)
   tag: fixed
-  bug: 1425962
+  bugs:
+  - 1425962
   group: 2
-- note: Messages moved between IMAP accounts were missing parts (embedded content or
-    attachments) under some circumstances
+- note: Messages moved between IMAP accounts were missing parts (embedded content or attachments)
+    under some circumstances
   tag: fixed
-  bug: 1430480
+  bugs:
+  - 1430480
   group: 2
 - note: 'Better error handling for Gmail authentication to avoid re-downloading of folders'
   tag: fixed
-  bug: 1453643
+  bugs:
+  - 1453643
   group: 2
 - note: Text in the address book card view wasn't selectable
   tag: fixed
-  bug: 96968
+  bugs:
+  - 96968
   group: 2
 - note: UTF-7 support (not working since Thunderbird version 56)
   tag: fixed
-  bug: 1402813
+  bugs:
+  - 1402813
   group: 2
-- note: 'Complete fix of the EFAIL vulnerability: 1) Removing some HTML crafted to carry out an attack.
-    2) Not decrypting subordinate message parts that otherwise might reveal decrypted content to the attacker.
-    Preference mailnews.p7m_subparts_external controls this.'
+- note: 'Complete fix of the EFAIL vulnerability: 1) Removing some HTML crafted to carry
+    out an attack. 2) Not decrypting subordinate message parts that otherwise might reveal
+    decrypted content to the attacker. Preference mailnews.p7m_subparts_external controls
+    this.'
   tag: fixed
-  bug: 1419417
+  bugs:
+  - 1419417
   group: 2
 - note: Thunderbird used a stale cached password after user edited a saved password
   tag: fixed
-  bug: 516464
+  bugs:
+  - 516464
   group: 2
-- note: 'The new menu item "Add-on Options" introduced in Thunderbird 59 beta is now also working on Mac'
+- note: 'The new menu item "Add-on Options" introduced in Thunderbird 59 beta is now also
+    working on Mac'
   tag: fixed
-  bug: 1419145
+  bugs:
+  - 1419145
   group: 2
-- note: "Source view not working for JS, XML, CSS, etc. source files via 'Developer Tools > Error Console'.
-    Other options: 1) Set preference view_source.editor.external and view_source.editor.path to view
-    the source in the editor of your choice. 2) Use 'Developer Tools > Developer Toolbox, Console'.
-    (not working in earlier versions of Thunderbird 60 beta)"
+- note: "Source view not working for JS, XML, CSS, etc. source files via 'Developer Tools\
+    \ > Error Console'. Other options: 1) Set preference view_source.editor.external and\
+    \ view_source.editor.path to view the source in the editor of your choice. 2) Use 'Developer\
+    \ Tools > Developer Toolbox, Console'. (not working in earlier versions of Thunderbird\
+    \ 60 beta)"
   tag: fixed
-  bug: 1439021
+  bugs:
+  - 1439021
   group: 2
 - note: Deleting or detaching attachments corrupted messages under certain circumstances
     (not working in earlier versions of Thunderbird 60 beta)
   tag: fixed
-  bug: 1473893
+  bugs:
+  - 1473893
   group: 2
 - note: 'Calendar: Google account credentials not retained by Lightning'
   tag: fixed
-  bug: 1468069
+  bugs:
+  - 1468069
   group: 2
 - note: 'Provider for Google Calendar not available'
   tag: unresolved
-  bug: 1471326
+  bugs:
+  - 1471326
   group: 2
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912
   group: 2

--- a/beta/63.0beta.yml
+++ b/beta/63.0beta.yml
@@ -1,68 +1,86 @@
 release:
   release_date: 2018-10-11
-  text: "**These release notes apply to Thunderbird version 63 beta 1 released October 11th, 2018.**
-    Note that Thunderbird version 61 beta and 62 beta were skipped."
+  text: "**These release notes apply to Thunderbird version 63 beta 1 released October\
+    \ 11th, 2018.** Note that Thunderbird version 61 beta and 62 beta were skipped."
   import_system_requirements: '60.0beta'
   groups:
-    -
-    - "Released in 60.2.1 ESR but not in TB60 beta 11."
+  - 
+  - "Released in 60.2.1 ESR but not in TB60 beta 11."
 
 notes:
 - note: 'Mark all folders of an account as read'
   tag: new
-  bug: 317301
-- note: 'Experimental feature: Language packs can now be selected in the Advanced Options. Preference
-    intl.multilingual.enabled needs to be set (and possily also extensions.langpacks.signatures.required
+  bugs:
+  - 317301
+- note: 'Experimental feature: Language packs can now be selected in the Advanced Options.
+    Preference intl.multilingual.enabled needs to be set (and possily also extensions.langpacks.signatures.required
     needs to be set to false)'
   tag: new
-  bug: 1491562
-- note: "**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made the necessary
-    minor adjustments. Non-restartless legacy add-ons using XUL overlays are only supported if add-on
-    authors have adapted them, and Lightning/Calendar is the only one we know that has been adapted.**"
+  bugs:
+  - 1491562
+- note: "**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made\
+    \ the necessary minor adjustments. Non-restartless legacy add-ons using XUL overlays\
+    \ are only supported if add-on authors have adapted them, and Lightning/Calendar is\
+    \ the only one we know that has been adapted.**"
   tag: changed
 - note: "Add-on overlays now loaded with Thunderbird's own overlay loader"
   tag: changed
-  bug: 1448808
+  bugs:
+  - 1448808
 - note: 'Improved phishing attempt detection for messages with certain forms'
   tag: changed
-  bug: 1249562
-- note: 'The stand-alone options window has been removed, all options are now shown in a tab'
+  bugs:
+  - 1249562
+- note: 'The stand-alone options window has been removed, all options are now shown in
+    a tab'
   tag: changed
-  bug: 1465061
+  bugs:
+  - 1465061
 - note: 'Thunderbird hung if HTML signature references non-existent image'
   tag: fixed
-  bug: 1495698
+  bugs:
+  - 1495698
 - note: 'Filters not working for headers that appear more than once'
   tag: fixed
-  bug: 678322
+  bugs:
+  - 678322
 - note: 'mbox to maildir conversion not working if Windows search integration is enabled'
   tag: fixed
-  bug: 1472524
+  bugs:
+  - 1472524
 # Below items released in 60.2.1 ESR but not included in TB60 beta 11.
-- note: "Links in the Add-on Manager's search results and theme browsing tabs open in external browser"
+- note: "Links in the Add-on Manager's search results and theme browsing tabs open in external\
+    \ browser"
   tag: fixed
-  bug: 1482342
-  bug2: 1481088
+  bugs:
+  - 1482342
+  - 1481088
   group: 2
-- note: 'Localized versions of Thunderbird didn''t show a localized name for the "Drafts" and "Sent" folders
-    for certain IMAP providers (particularly in France)'
+- note: 'Localized versions of Thunderbird didn''t show a localized name for the "Drafts"
+    and "Sent" folders for certain IMAP providers (particularly in France)'
   tag: fixed
-  bug: 543227
+  bugs:
+  - 543227
   group: 2
 - note: 'Replying to a message with an empty subject inserted Re: twice'
   tag: fixed
-  bug: 1476788
+  bugs:
+  - 1476788
   group: 2
-- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced Property Editor
-    or Link Properties dialog'
+- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced
+    Property Editor or Link Properties dialog'
   tag: unresolved
-  bug: 1501663
+  bugs:
+  - 1501663
   group: 2
-- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (is working in Thunderbird 60 ESR)'
+- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (is working
+    in Thunderbird 60 ESR)'
   tag: unresolved
-  bug: 1418629
+  bugs:
+  - 1418629
   group: 2
 - note: 'Chat: Twitter not working due to API changes at Twitter.com (solution forthcoming)'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778
   group: 2

--- a/beta/64.0beta.yml
+++ b/beta/64.0beta.yml
@@ -1,145 +1,183 @@
 release:
   release_date: 2018-10-26
-  text: "**These release notes apply to Thunderbird version 64 beta 4 released December 2nd, 2018.**"
+  text: "**These release notes apply to Thunderbird version 64 beta 4 released December\
+    \ 2nd, 2018.**"
   import_system_requirements: '60.0beta'
   groups:
-    -
-    - "Beta 2"
-    - "Beta 3"
-    - "Beta 4"
+  - 
+  - "Beta 2"
+  - "Beta 3"
+  - "Beta 4"
 
 notes:
-- note: "**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made the necessary
-    minor adjustments. Non-restartless legacy add-ons using XUL overlays are only supported if add-on
-    authors have adapted them, and Lightning/Calendar is the only one we know that has been adapted.**"
+- note: "**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made\
+    \ the necessary minor adjustments. Non-restartless legacy add-ons using XUL overlays\
+    \ are only supported if add-on authors have adapted them, and Lightning/Calendar is\
+    \ the only one we know that has been adapted.**"
   tag: changed
 - note: "Changed UI when installing add-ons. Restart required for legacy extensions."
   tag: changed
-  bug: 1496632
-  bug2: 1498967
+  bugs:
+  - 1496632
+  - 1498967
 - note: "Calendar: UI improvements for event dialog"
   tag: changed
-  bug: 1496086
+  bugs:
+  - 1496086
 - note: 'Print preview not working in Thunderbird version 63 beta'
   tag: fixed
-  bug: 1495898
+  bugs:
+  - 1495898
 - note: 'Various Theme fixes where incorrect colors, backgrounds, etc. were displayed.
     Folders with new messages not shown in bold on Mac.'
   tag: fixed
-  bug: 1498908
+  bugs:
+  - 1498908
 - note: 'Add-on Options menu not working on Mac'
   tag: fixed
-  bug: 1482334
+  bugs:
+  - 1482334
 - note: 'Shift+PageUp/PageDown in Write window'
   tag: fixed
-  bug: 1482425
+  bugs:
+  - 1482425
 - note: 'Saving content of Write windows didn''t overwrite existing file'
   tag: fixed
-  bug: 1498483
+  bugs:
+  - 1498483
 - note: 'Issues related to "Edit Template" command'
   tag: fixed
-  bug: 1498866
+  bugs:
+  - 1498866
 - note: 'Gloda attachment filtering'
   tag: fixed
-  bug: 1499860
+  bugs:
+  - 1499860
 - note: 'S/MIME encryption/signing not working in Thunderbird version 63 beta'
   tag: fixed
-  bug: 1500003
+  bugs:
+  - 1500003
 - note: 'Body search/filtering didn''t reliably ignore content of tags'
   tag: fixed
-  bug: 1230815
-- note: 'Mails won''t get removed from Trash folder using Maildir.
-    Note: Other deletion issues related to Maildir still persist.'
+  bugs:
+  - 1230815
+- note: 'Mails won''t get removed from Trash folder using Maildir. Note: Other deletion
+    issues related to Maildir still persist.'
   tag: fixed
-  bug: 1317117
+  bugs:
+  - 1317117
 - note: 'If the "Date" header of a message was invalid, Jan 1970 or Dec 1969 was displayed.
     Now using date from "Received" header instead.'
   tag: fixed
-  bug: 32216
+  bugs:
+  - 32216
 - note: 'Mailing list address auto-complete enter/return handling'
   tag: fixed
-  bug: 1499410
-- note: 'When sending of a message failed due a security issue, only "unknown error" was displayed.
-    Now more details are given.'
+  bugs:
+  - 1499410
+- note: 'When sending of a message failed due a security issue, only "unknown error" was
+    displayed. Now more details are given.'
   tag: fixed
-  bug: 1497488
+  bugs:
+  - 1497488
 - note: '"Select All" in mail view not working in Thunderbird version 63 beta'
   tag: fixed
-  bug: 1498588
+  bugs:
+  - 1498588
 # Beta 2 below.
-- note: 'According to RFC 4616 and RFC 5721, passwords containing non-ASCII characters are
-    encoded using UTF-8 which can lead to problems with non-compliant providers, for example
-    office365.com. The SMTP LOGIN and POP3 USER/PASS authentication methods are now using
-    a Latin-1 encoding again to work around this issue.'
+- note: 'According to RFC 4616 and RFC 5721, passwords containing non-ASCII characters
+    are encoded using UTF-8 which can lead to problems with non-compliant providers, for
+    example office365.com. The SMTP LOGIN and POP3 USER/PASS authentication methods are
+    now using a Latin-1 encoding again to work around this issue.'
   tag: fixed
-  bug: 1500772
+  bugs:
+  - 1500772
   group: 2
 - note: '"Download rest of message" not working if global inbox was used'
   tag: fixed
-  bug: 1503395
+  bugs:
+  - 1503395
   group: 2
 - note: 'Shutdown crash/hang after entering an empty IMAP password'
   tag: fixed
-  bug: 1257058
+  bugs:
+  - 1257058
   group: 2
 # Beta 3 below.
 - note: 'Cookie removal (not working since Thunderbird version 52)'
   tag: fixed
-  bug: 1503654
+  bugs:
+  - 1503654
   group: 3
-- note: 'Encoding problems for users (especially in Poland) when a file was sent via a folder using
-    "Sent to > Mail recipient" due to a problem in the Thunderbird MAPI interface'
+- note: 'Encoding problems for users (especially in Poland) when a file was sent via a
+    folder using "Sent to > Mail recipient" due to a problem in the Thunderbird MAPI interface'
   tag: fixed
-  bug: 1505315
+  bugs:
+  - 1505315
   group: 3
-- note: 'Under some circumstances Thunderbird on Mac would send attachments using the
-    so-called AppleDouble format which could lead to problems with mail servers and recipients'
+- note: 'Under some circumstances Thunderbird on Mac would send attachments using the so-called
+    AppleDouble format which could lead to problems with mail servers and recipients'
   tag: fixed
-  bug: 1506800
+  bugs:
+  - 1506800
   group: 3
 - note: 'Encoding problems when exporting address books or messages using the system charset.
     Messages are now always exported using the UTF-8 encoding.'
   tag: fixed
-  bug: 1506422
+  bugs:
+  - 1506422
   group: 3
 # Beta 4 below.
 - note: 'Inappropriate warning "Thunderbird prevented the site (addons.thunderbird.net)
     from asking you to install software on your computer" when installing add-ons'
   tag: fixed
-  bug: 1230815
+  bugs:
+  - 1230815
   group: 4
-- note: 'Incorrect display of correspondents column since own email address was not always detected'
+- note: 'Incorrect display of correspondents column since own email address was not always
+    detected'
   tag: fixed
-  bug: 1271353
+  bugs:
+  - 1271353
   group: 4
-- note: 'New email not inserted in correct sort order in threaded unified view or search folder'
+- note: 'New email not inserted in correct sort order in threaded unified view or search
+    folder'
   tag: fixed
-  bug: 1470049
+  bugs:
+  - 1470049
   group: 4
-- note: 'Spurious &amp;#xA; (encoded newline) inserted into drafts and sent email
-    (working in Thunderbird ESR, will be fixed in version 65 beta)'
+- note: 'Spurious &amp;#xA; (encoded newline) inserted into drafts and sent email (working
+    in Thunderbird ESR, will be fixed in version 65 beta)'
   tag: unresolved
-  bug: 1509102
+  bugs:
+  - 1509102
   group: 4
-- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced Property Editor
-    or Link Properties dialog (working in Thunderbird ESR, will be fixed in version 65 beta)'
+- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced
+    Property Editor or Link Properties dialog (working in Thunderbird ESR, will be fixed
+    in version 65 beta)'
   tag: unresolved
-  bug: 1501663
+  bugs:
+  - 1501663
   group: 4
-- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (working in Thunderbird ESR)'
+- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (working
+    in Thunderbird ESR)'
   tag: unresolved
-  bug: 1418629
+  bugs:
+  - 1418629
   group: 4
 - note: 'Editing a plaint text draft may display the entire message as quote (in blue)
     (working in Thunderbird ESR, will be fixed in version 65 beta)'
   tag: unresolved
-  bug: 1501259
+  bugs:
+  - 1501259
   group: 4
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778
   group: 4
 - note: 'Chat: Participants not sorted'
   tag: unresolved
-  bug: 1480057
+  bugs:
+  - 1480057
   group: 4

--- a/beta/65.0beta.yml
+++ b/beta/65.0beta.yml
@@ -1,146 +1,185 @@
 release:
   release_date: 2018-12-30
-  text: "**These release notes apply to Thunderbird version 65 beta 4 released January 29th, 2019.**"
+  text: "**These release notes apply to Thunderbird version 65 beta 4 released January\
+    \ 29th, 2019.**"
   import_system_requirements: '60.0beta'
   groups:
-    -
-    - "Beta 2"
-    - "Beta 3"
-    - "Beta 4"
+  - 
+  - "Beta 2"
+  - "Beta 3"
+  - "Beta 4"
 
 notes:
 - note: 'FileLink for WeTransfer'
   tag: new
-  bug: 1504508
-- note: 'WebExtensions FileLink API to facilitate FileLink add-ons.
-    WeTransfer is already included and Dropbox is available as [add-on](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/).'
+  bugs:
+  - 1504508
+- note: 'WebExtensions FileLink API to facilitate FileLink add-ons. WeTransfer is already
+    included and Dropbox is available as [add-on](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/).'
   tag: new
-  bug: 1511950
+  bugs:
+  - 1511950
 - note: 'Various theme improvements including a dark message list/thread pane'
   tag: new
-  bug: 1504187
-- note: 'When multiple language packs are installed, the UI language can now be selected in the Advanced Options.
-    Preference
-    intl.multilingual.enabled needs to be set (and possily also extensions.langpacks.signatures.required
-    needs to be set to false)'
+  bugs:
+  - 1504187
+- note: 'When multiple language packs are installed, the UI language can now be selected
+    in the Advanced Options. Preference intl.multilingual.enabled needs to be set (and
+    possily also extensions.langpacks.signatures.required needs to be set to false)'
   tag: new
-  bug: 1509977
-- note: '**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made the necessary
-    minor adjustments. Non-restartless legacy add-ons using XUL overlays are only supported if add-on
-    authors have adapted them. ** Apart from Lightning/Calendar there are a few that have been
-    adapted, like "ThunderHTMLedit", "Compact Header" and "Signature Switch".
-    Instaling legacy add-ons now requires a restart. Legacy add-ons can now specify
-    an options page again.'
+  bugs:
+  - 1509977
+- note: '**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made
+    the necessary minor adjustments. Non-restartless legacy add-ons using XUL overlays
+    are only supported if add-on authors have adapted them. ** Apart from Lightning/Calendar
+    there are a few that have been adapted, like "ThunderHTMLedit", "Compact Header" and
+    "Signature Switch". Instaling legacy add-ons now requires a restart. Legacy add-ons
+    can now specify an options page again.'
   tag: changed
-- note: '** DICTIONARY SUPPORT: Only WebExtension dictionaries are supported now.**
-    Please download new dictionaries from addons.mozilla.org since
-    addons.thunderbird.net still provides "legacy" dictionaries compatible
-    with Thunderbird 60 ESR. This may change as soon as Thunderbird 60 ESR
-    can also handle WebExtension dictionaries (planned for version 60.5).'
+- note: '** DICTIONARY SUPPORT: Only WebExtension dictionaries are supported now.** Please
+    download new dictionaries from addons.mozilla.org since addons.thunderbird.net still
+    provides "legacy" dictionaries compatible with Thunderbird 60 ESR. This may change
+    as soon as Thunderbird 60 ESR can also handle WebExtension dictionaries (planned for
+    version 60.5).'
   tag: changed
-  bug: 1516273
-- note: 'Reply to self will now search all identities (default of preference
-    mailnews.reply_to_self_check_all_ident changed to true)'
-  bug: 1511723
+  bugs:
+  - 1516273
+- note: 'Reply to self will now search all identities (default of preference mailnews.reply_to_self_check_all_ident
+    changed to true)'
+  bugs:
+  - 1511723
   tag: changed
 - note: 'Composition text and background colors no longer sent by default. New option in
     "Tools > Options, Composition".'
-  bug: 690644
+  bugs:
+  - 690644
   tag: changed
 - note: 'Address book search and auto-complete slowness introduced in Thunderbird 64 beta'
   tag: fixed
-  bug: 1511885
-- note: 'Plain text markup with * for bold, / for italics, _ for underline and | for code did not
-    work when the enclosed text contained non-ASCII characters'
+  bugs:
+  - 1511885
+- note: 'Plain text markup with * for bold, / for italics, _ for underline and | for code
+    did not work when the enclosed text contained non-ASCII characters'
   tag: fixed
-  bug: 1505911
-- note: 'While composing a message, a link not removed when link location was removed in the link properties panel'
+  bugs:
+  - 1505911
+- note: 'While composing a message, a link not removed when link location was removed in
+    the link properties panel'
   tag: fixed
-  bug: 1510183
+  bugs:
+  - 1510183
 - note: 'Decoding problems for messages with less common charsets (cp932, cp936)'
   tag: fixed
-  bug: 1511950
+  bugs:
+  - 1511950
 - note: 'Spurious &amp;#xA; (encoded newline) inserted into drafts and sent email'
   tag: fixed
-  bug: 1509102
-- note: 'Double-clicking on a word in the Write window sometimes launched the Advanced Property Editor
-    or Link Properties dialog'
+  bugs:
+  - 1509102
+- note: 'Double-clicking on a word in the Write window sometimes launched the Advanced
+    Property Editor or Link Properties dialog'
   tag: fixed
-  bug: 1501663
+  bugs:
+  - 1501663
 - note: 'Editing a plaint text draft displayed the entire message as quote (in blue)'
   tag: fixed
-  bug: 1501259
+  bugs:
+  - 1501259
 - note: 'New messages in the drafts folder (and other special or virtual folders) will
     no longer be included in the new messages notification'
   tag: fixed
-  bug: 809513
+  bugs:
+  - 809513
 - note: 'Edit > Undo didn''t undo moving or deleting of messages'
   tag: fixed
-  bug: 1508210
+  bugs:
+  - 1508210
 - note: 'Improvements of SMTP 5.7.1 message'
   tag: fixed
-  bug: 1195026
+  bugs:
+  - 1195026
 # Beta 2 below.
-- note: 'Thunderbird now allows the addition of OpenSearch search engines from a local XML file
-    using a minimal user inferface: [+] button to select a file an add, [-] to remove.'
+- note: 'Thunderbird now allows the addition of OpenSearch search engines from a local
+    XML file using a minimal user inferface: [+] button to select a file an add, [-] to
+    remove.'
   tag: new
-  bug: 1427317
+  bugs:
+  - 1427317
   group: 2
-- note: 'During account creation, Thunderbird will now detect servers using the Microsoft Exchange protocol.
-    It will offer the installation of a 3rd party add-on (Owl) which supports that protocol.'
+- note: 'During account creation, Thunderbird will now detect servers using the Microsoft
+    Exchange protocol. It will offer the installation of a 3rd party add-on (Owl) which
+    supports that protocol.'
   tag: new
-  bug: 1500105
+  bugs:
+  - 1500105
   group: 2
-- note: 'Account creation sometimes shows an error: "Programming bug. Assertion failed, see log"'
+- note: 'Account creation sometimes shows an error: "Programming bug. Assertion failed,
+    see log"'
   tag: fixed
-  bug: 1516134
+  bugs:
+  - 1516134
   group: 2
 - note: 'Chat: Participants not sorted (not working since Thunderbird 63 beta)'
   tag: fixed
-  bug: 1480057
+  bugs:
+  - 1480057
   group: 2
 # Beta 3 below.
 - note: 'More search engines: Google and DuckDuckGo available by default'
   tag: new
-  bug: 1427133
+  bugs:
+  - 1427133
   group: 3
-- note: 'Crash when using "Send to > Mail recipient" on Windows under some circumstances (MAPI interface)'
+- note: 'Crash when using "Send to > Mail recipient" on Windows under some circumstances
+    (MAPI interface)'
   tag: fixed
-  bug: 393302
+  bugs:
+  - 393302
   group: 3
 # Beta 4 below.
-- note: 'Full Unicode support for MAPI interfaces: New support for MAPISendMailW, UTF-8 support for MAPISendMail'
+- note: 'Full Unicode support for MAPI interfaces: New support for MAPISendMailW, UTF-8
+    support for MAPISendMail'
   tag: fixed
-  bug: 1048658
-  bug2: 1521007
+  bugs:
+  - 1048658
+  - 1521007
   group: 4
 - note: 'Chat: Participants not sorted (follow-up)'
   tag: fixed
-  bug: 1521097
+  bugs:
+  - 1521097
   group: 4
 - note: 'Calendar print preview not working'
   tag: fixed
-  bug: 1517155
+  bugs:
+  - 1517155
   group: 4
 - note: 'CalDav access to some servers not working'
   tag: fixed
-  bug: 1468912
+  bugs:
+  - 1468912
   group: 4
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
   group: 4
-- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (working in Thunderbird ESR)'
+- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (working
+    in Thunderbird ESR)'
   tag: unresolved
-  bug: 1418629
+  bugs:
+  - 1418629
   group: 4
-- note: 'Calendar: A localized version of Provider for Google Calendar not available at addons.thunderbird.net or
-    the Mozilla FTP server. A US-English version can be downloaded [here](https://queue.taskcluster.net/v1/task/XEFE1Xk_TTCLs5TedrG1Kw/runs/0/artifacts/public/build/gdata-provider.en-US.xpi).'
+- note: 'Calendar: A localized version of Provider for Google Calendar not available at
+    addons.thunderbird.net or the Mozilla FTP server. A US-English version can be downloaded
+    [here](https://queue.taskcluster.net/v1/task/XEFE1Xk_TTCLs5TedrG1Kw/runs/0/artifacts/public/build/gdata-provider.en-US.xpi).'
   tag: unresolved
-  bug: 1516816
+  bugs:
+  - 1516816
   group: 4
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778
   group: 4

--- a/beta/66.0beta.yml
+++ b/beta/66.0beta.yml
@@ -1,90 +1,106 @@
 release:
   release_date: 2019-02-12
-  text: "**These release notes apply to Thunderbird version 66 beta 3 released March 8th, 2019.**"
+  text: "**These release notes apply to Thunderbird version 66 beta 3 released March 8th,\
+    \ 2019.**"
   import_system_requirements: '60.0beta'
   groups:
-    -
-    - "Fixed in Beta 2"
-    - "Fixed in Beta 3"
+  - 
+  - "Fixed in Beta 2"
+  - "Fixed in Beta 3"
 
 notes:
-- note: '**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made the necessary
-    minor adjustments. Non-restartless legacy add-ons using XUL overlays are only supported if add-on
-    authors have adapted them. ** Apart from Lightning/Calendar there are a few that have been
-    adapted, like "ThunderHTMLedit", "Compact Header" and "Signature Switch".
-    Instaling legacy add-ons now requires a restart. Legacy add-ons can now specify
-    an options page again.'
+- note: '**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made
+    the necessary minor adjustments. Non-restartless legacy add-ons using XUL overlays
+    are only supported if add-on authors have adapted them. ** Apart from Lightning/Calendar
+    there are a few that have been adapted, like "ThunderHTMLedit", "Compact Header" and
+    "Signature Switch". Instaling legacy add-ons now requires a restart. Legacy add-ons
+    can now specify an options page again.'
   tag: changed
-- note: '** DICTIONARY SUPPORT: Only WebExtension dictionaries are supported now.**
-    Please download new dictionaries from addons.mozilla.org since
-    addons.thunderbird.net still provides "legacy" dictionaries compatible
-    with Thunderbird 60 ESR. Note that Thunderbird 60.5 ESR
-    can also handle WebExtension dictionaries.'
+- note: '** DICTIONARY SUPPORT: Only WebExtension dictionaries are supported now.** Please
+    download new dictionaries from addons.mozilla.org since addons.thunderbird.net still
+    provides "legacy" dictionaries compatible with Thunderbird 60 ESR. Note that Thunderbird
+    60.5 ESR can also handle WebExtension dictionaries.'
   tag: changed
-  bug: 1516273
+  bugs:
+  - 1516273
 - note: 'Maildir now uses the message ID as file name and "eml" as file extension'
-  bug: 1259040
-  bug2: 1144478
+  bugs:
+  - 1259040
+  - 1144478
   tag: changed
 - note: 'Tags set on IMAP folders sometimes not visible to other users'
-  bug: 583677
+  bugs:
+  - 583677
   tag: fixed
 - note: 'Various theme fixes and improvements'
   tag: fixed
   # Beta 2 below.
 - note: 'On Windows, changed options not saved (issue introduced in beta 1)'
-  bug: 1528615
+  bugs:
+  - 1528615
   tag: fixed
   group: 2
-- note: 'Problem with S/MIME certificate verification when receiving email from Outlook (issue introduced
-    in beta 1)'
-  bug: 1528615
+- note: 'Problem with S/MIME certificate verification when receiving email from Outlook
+    (issue introduced in beta 1)'
+  bugs:
+  - 1528615
   tag: fixed
   group: 2
 - note: 'Partly reverted MAPI changes from Thunderbird 65 beta 4 to mitigate malfunction'
-  bug: 1527450
+  bugs:
+  - 1527450
   tag: fixed
   group: 2
 - note: 'Custom tag colors outside the prior fixed 10x7 matrix of HTML colors not working.
     Now any chosen color will work.'
-  bug: 1497041
+  bugs:
+  - 1497041
   tag: fixed
   group: 3
 - note: 'On Windows, dragging message to the desktop or a folder is not working'
   tag: fixed
-  bug: 1526971
+  bugs:
+  - 1526971
   # Beta 3 below.
   group: 3
-- note: 'Fixed Windows installer with respect to MAPI DLLs and re-enabled MAPISendMailW which
-    was disabled in beta 2.<br>
-    If files with non-ASCII characters in their name still cause a malfunction, use one of the following two alternative solutions:<br>
-    <ul>
-    <li>Reset this registry entry<br>HKLM\SOFTWARE\Clients\Mail\Mozilla Thunderbird - SupportUTF8 to 0. Also reset HKLM\SOFTWARE\Wow6432Node\Clients\Mail\Mozilla Thunderbird - SupportUTF8 if present.</li>
-    <li>On Windows 10, set the system code page to UTF-8 (beta feature, see Region Settings, system locale)</li>
-    </ul>'
+- note: 'Fixed Windows installer with respect to MAPI DLLs and re-enabled MAPISendMailW
+    which was disabled in beta 2.<br> If files with non-ASCII characters in their name
+    still cause a malfunction, use one of the following two alternative solutions:<br>
+    <ul> <li>Reset this registry entry<br>HKLM\SOFTWARE\Clients\Mail\Mozilla Thunderbird
+    - SupportUTF8 to 0. Also reset HKLM\SOFTWARE\Wow6432Node\Clients\Mail\Mozilla Thunderbird
+    - SupportUTF8 if present.</li> <li>On Windows 10, set the system code page to UTF-8
+    (beta feature, see Region Settings, system locale)</li> </ul>'
   tag: fixed
-  bug: 1531724
-  bug2: 1531869
+  bugs:
+  - 1531724
+  - 1531869
   group: 3
 - note: 'Chat: Fixed XMPP authentication when using SASL'
-  bug: 1527480
+  bugs:
+  - 1527480
   tag: fixed
   group: 3
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
   group: 3
-- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (working in Thunderbird ESR)'
+- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (working
+    in Thunderbird ESR)'
   tag: unresolved
-  bug: 1418629
+  bugs:
+  - 1418629
   group: 3
-- note: 'Calendar: A localized version of Provider for Google Calendar not available at addons.thunderbird.net or
-    the Mozilla FTP server. A US-English version can be downloaded [here](https://queue.taskcluster.net/v1/task/S-3rciDeS3Gs3cLDeHSXeQ/runs/0/artifacts/public/build/gdata-provider.en-US.xpi).'
+- note: 'Calendar: A localized version of Provider for Google Calendar not available at
+    addons.thunderbird.net or the Mozilla FTP server. A US-English version can be downloaded
+    [here](https://queue.taskcluster.net/v1/task/S-3rciDeS3Gs3cLDeHSXeQ/runs/0/artifacts/public/build/gdata-provider.en-US.xpi).'
   tag: unresolved
-  bug: 1516816
+  bugs:
+  - 1516816
   group: 3
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778
   group: 3

--- a/beta/67.0beta.yml
+++ b/beta/67.0beta.yml
@@ -1,72 +1,94 @@
 release:
   release_date: 2019-04-02
-  text: "**These release notes apply to Thunderbird version 67 beta 3 released May 10th, 2019.**"
+  text: "**These release notes apply to Thunderbird version 67 beta 3 released May 10th,\
+    \ 2019.**"
   import_system_requirements: '60.0beta'
   groups:
-    -
-    - "Changed and Fixed in Beta 2"
-    - "Fixed in Beta 3"
+  - 
+  - "Changed and Fixed in Beta 2"
+  - "Fixed in Beta 3"
 
 notes:
-- note: '**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made the necessary
-    minor adjustments. Non-restartless legacy add-ons using XUL overlays are only supported if add-on
-    authors have adapted them. ** Apart from Lightning/Calendar there are a few that have been
-    adapted, like "ThunderHTMLedit", "Compact Header", "Signature Switch" and "Send Later".'
+- note: '**ADD-ON SUPPORT: Restartless add-ons continue to work if their authors have made
+    the necessary minor adjustments. Non-restartless legacy add-ons using XUL overlays
+    are only supported if add-on authors have adapted them. ** Apart from Lightning/Calendar
+    there are a few that have been adapted, like "ThunderHTMLedit", "Compact Header", "Signature
+    Switch" and "Send Later".'
   tag: changed
-- note: '** DICTIONARY SUPPORT: Only WebExtension dictionaries are supported now.**
-    Both addons.mozilla.org and addons.thunderbird.net now provide WebExtension dictionaries.'
+- note: '** DICTIONARY SUPPORT: Only WebExtension dictionaries are supported now.** Both
+    addons.mozilla.org and addons.thunderbird.net now provide WebExtension dictionaries.'
   tag: changed
 - note: 'Improvements when entering, selecting and removing recipients in the Write window'
-  bug: 1493158
-  bug2: 1527547
+  bugs:
+  - 1493158
+  - 1527547
   tag: changed
   # Beta 2 below.
-- note: 'Attachment pane of Write window no longer focussed when attaching files using a keyboard shortcut'
+- note: 'Attachment pane of Write window no longer focussed when attaching files using
+    a keyboard shortcut'
   tag: changed
-  bug: 1519328
+  bugs:
+  - 1519328
   group: 2
 - note: 'Navigation of attachments in Write window'
   tag: fixed
-  bug: 1526811
-  bug2: 1542317
+  bugs:
+  - 1526811
+  - 1542317
   group: 2
-- note: 'Insufficient contrast between forground and background colors for some tagged messages'
+- note: 'Insufficient contrast between forground and background colors for some tagged
+    messages'
   tag: fixed
-  bug: 1534360
+  bugs:
+  - 1534360
   group: 2
 - note: 'IMAP offline folder selection not working'
   tag: fixed
-  bug: 1546604
+  bugs:
+  - 1546604
   group: 3
 - note: 'Installation problems on 32-bit Windows'
   tag: fixed
-  bug: 1547631
+  bugs:
+  - 1547631
   group: 3
 - note: 'Customising From address breaks saving draft and sending message'
   tag: unresolved
-  bug: 1542667
+  bugs:
+  - 1542667
 - note: 'Malfunction when deleting a message opened in a tab or stand-alone window'
   tag: unresolved
-  bug: 1518823
-- note: 'Thunderbird 67 beta may not recognise an existing profile. Workaround: start with the profile manager option -p.'
+  bugs:
+  - 1518823
+- note: 'Thunderbird 67 beta may not recognise an existing profile. Workaround: start with
+    the profile manager option -p.'
   tag: unresolved
-  bug: 1542025
-- note: 'Thunderbird 67 beta may display a message "You''ve launched an older version of Firefox" and will not
-  allow opening a specific profile. Workaround: start with option --allow-downgrade.'
+  bugs:
+  - 1542025
+- note: 'Thunderbird 67 beta may display a message "You''ve launched an older version of
+    Firefox" and will not allow opening a specific profile. Workaround: start with option
+    --allow-downgrade.'
   tag: unresolved
-  bug: 1535116
+  bugs:
+  - 1535116
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
-- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (working in Thunderbird ESR)'
+  bugs:
+  - 1512812
+- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (working
+    in Thunderbird ESR)'
   tag: unresolved
-  bug: 1418629
-- note: 'Calendar: A localized version of Provider for Google Calendar not available at addons.thunderbird.net or
-    the Mozilla FTP server. A US-English version can be downloaded [here](https://queue.taskcluster.net/v1/task/VM8btfxVSEKx6RZHQxl0jg/runs/0/artifacts/public/build/gdata-provider.en-US.xpi).
+  bugs:
+  - 1418629
+- note: 'Calendar: A localized version of Provider for Google Calendar not available at
+    addons.thunderbird.net or the Mozilla FTP server. A US-English version can be downloaded
+    [here](https://queue.taskcluster.net/v1/task/VM8btfxVSEKx6RZHQxl0jg/runs/0/artifacts/public/build/gdata-provider.en-US.xpi).
     The XPI file needs to be installed manually in Thunderbird.'
   tag: unresolved
-  bug: 1516816
+  bugs:
+  - 1516816
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/beta/68.0beta.yml
+++ b/beta/68.0beta.yml
@@ -13,7 +13,7 @@ notes:
 - note: 'Run filters periodically. Improved filter logging.'
   tag: new
   bug: 864187
-  bug: 697522
+  bug2: 697522
 - note: '"Off the record" (OTR) chat, see the [Wiki](https://wiki.mozilla.org/Thunderbird:OTR)'
   tag: new
   bug: 1518172

--- a/beta/68.0beta.yml
+++ b/beta/68.0beta.yml
@@ -1,127 +1,155 @@
 release:
   release_date: 2019-06-14
-  text: "**These release notes apply to Thunderbird version 68 beta 5 released July 18th, 2019.**"
+  text: "**These release notes apply to Thunderbird version 68 beta 5 released July 18th,\
+    \ 2019.**"
   import_system_requirements: '60.0beta'
   groups:
-    -
-    - "Changed and Fixed in Beta 2"
-    - "New, Changed and Fixed in Beta 3"
-    - "Changed and Fixed in Beta 4"
-    - "Fixed in Beta 5"
+  - 
+  - "Changed and Fixed in Beta 2"
+  - "New, Changed and Fixed in Beta 3"
+  - "Changed and Fixed in Beta 4"
+  - "Fixed in Beta 5"
 
 notes:
 - note: 'Run filters periodically. Improved filter logging.'
   tag: new
-  bug: 864187
-  bug2: 697522
+  bugs:
+  - 864187
+  - 697522
 - note: '"Off the record" (OTR) chat, see the [Wiki](https://wiki.mozilla.org/Thunderbird:OTR)'
   tag: new
-  bug: 1518172
+  bugs:
+  - 1518172
 - note: 'File link attachments can now be linked to again instead of uploading them again'
   tag: new
-  bug: 1542991
-- note: 'Added a policy engine that allows customized Thunderbird deployments in enterprise environments,
-    using Windows Group Policy or a cross-platform JSON file'
+  bugs:
+  - 1542991
+- note: 'Added a policy engine that allows customized Thunderbird deployments in enterprise
+    environments, using Windows Group Policy or a cross-platform JSON file'
   tag: new
-  bug: 1552457
+  bugs:
+  - 1552457
 - note: 'TCP keepalive for IMAP protocol'
   tag: new
-  bug: 1535969
-- note: '**Add-on support: Restartless add-ons and non-restartless legacy add-ons using XUL overlays
-    are only supported if add-on authors have adapted them**'
+  bugs:
+  - 1535969
+- note: '**Add-on support: Restartless add-ons and non-restartless legacy add-ons using
+    XUL overlays are only supported if add-on authors have adapted them**'
   tag: changed
-  bug: 1552634
-- note: '**Theme support**: Thunderbird no longer supports so-called lightweight themes. Therefore
-    none of the themes offered at addons.thunderbird.net currently work.
-    Lightweight themes will be converted to WebExtension themes, but
-    this conversion has NOT happened yet. It has happened at addons.mozilla.org.
-    Workaround: Manually install from
-    [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/themes/) by dragging the link
-    or .xpi file into the Add-ons Manager.'
+  bugs:
+  - 1552634
+- note: '**Theme support**: Thunderbird no longer supports so-called lightweight themes.
+    Therefore none of the themes offered at addons.thunderbird.net currently work. Lightweight
+    themes will be converted to WebExtension themes, but this conversion has NOT happened
+    yet. It has happened at addons.mozilla.org. Workaround: Manually install from [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/themes/)
+    by dragging the link or .xpi file into the Add-ons Manager.'
   tag: changed
 - note: 'Application menu aka "Hamburger menu"'
   tag: changed
-  bug: 1546309
+  bugs:
+  - 1546309
 - note: 'Box.com file link provider was removed and is now available as add-on at [ATN](https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-box/)'
   tag: changed
-  bug: 1531595
+  bugs:
+  - 1531595
 - note: 'UI improvements for external attachments'
   tag: changed
-  bug: 1345167
+  bugs:
+  - 1345167
 - note: 'Improvements to scam warnings'
   tag: changed
-  bug: 1476428
+  bugs:
+  - 1476428
 - note: 'Various UI improvements. Many changes affecting UI, and so problems are expected.
     Please file bug reports at [bugzilla.mozilla.org](https://bugzilla.mozilla.org/).'
   tag: changed
 - note: 'Malfunction when deleting a message opened in a tab or stand-alone window'
   tag: fixed
-  bug: 1518823
+  bugs:
+  - 1518823
 - note: 'Blank new mail notification under some circumstances'
   tag: fixed
-  bug: 1547202
+  bugs:
+  - 1547202
 - note: 'Spellcheck marks disappeared erroneously for words with an apostrophe'
   tag: fixed
-  bug: 1418629
+  bugs:
+  - 1418629
   # Beta 2 below.
 - note: Various theme improvements.
   tag: changed
-  bug: 1559833
-  bug2: 1559176
+  bugs:
+  - 1559833
+  - 1559176
   group: 2
-- note: 'SMTP password wasn''t removed when account was deleted or server or user name were changed'
+- note: 'SMTP password wasn''t removed when account was deleted or server or user name
+    were changed'
   tag: fixed
-  bug: 1315662
+  bugs:
+  - 1315662
   group: 2
-- note: 'Calendar: Multiple connections with different users to the same CalDAV server not working'
+- note: 'Calendar: Multiple connections with different users to the same CalDAV server
+    not working'
   tag: fixed
-  bug: 1544596
+  bugs:
+  - 1544596
   group: 2
-- note: 'Chat: Context (right-click) menu and spelling. In each conversation an individual spellcheck language
-  can be selected now.'
+- note: 'Chat: Context (right-click) menu and spelling. In each conversation an individual
+    spellcheck language can be selected now.'
   tag: fixed
-  bug: 1556203
-  bug2: 1559789
+  bugs:
+  - 1556203
+  - 1559789
   group: 2
   # Beta 3 below.
 - note: 'OAuth2 authentication for Yandex'
   tag: new
-  bug: 1559972
+  bugs:
+  - 1559972
   group: 3
 - note: 'Auto-compact threshold increased from 20 MB to 200 MB'
   tag: changed
-  bug: 1462666
+  bugs:
+  - 1462666
   group: 3
 - note: 'Customising From address broke saving draft and sending message'
   tag: fixed
-  bug: 1542667
+  bugs:
+  - 1542667
   group: 3
 - note: 'Chat: Status selector not working'
   tag: fixed
-  bug: 1559641
+  bugs:
+  - 1559641
   group: 3
   # Beta 4 below.
-- note: 'Thunderbird 68 beta may display a message "You have launched an older version of Thunderbird" and will not
-  allow opening a specific profile. Workaround: start with option --allow-downgrade.'
+- note: 'Thunderbird 68 beta may display a message "You have launched an older version
+    of Thunderbird" and will not allow opening a specific profile. Workaround: start with
+    option --allow-downgrade.'
   tag: changed
-  bug: 1535116
+  bugs:
+  - 1535116
   group: 4
 - note: 'Find toolbar not fully working'
   tag: fixed
-  bug: 1562677
+  bugs:
+  - 1562677
   group: 4
 - note: 'Display of external or detached attachments not correct in message preview'
   tag: fixed
-  bug: 1562200
+  bugs:
+  - 1562200
   group: 4
 - note: 'Tab and shift-tab not fully working on the main window'
   tag: fixed
-  bug: 1561288
-  bug2: 1558393
+  bugs:
+  - 1561288
+  - 1558393
   group: 4
 - note: 'Chat: Ctrl+D and Ctrl+U not working to switch between conversations'
   tag: fixed
-  bug: 1559097
+  bugs:
+  - 1559097
   group: 4
 - note: 'Calendar: Many fixes in Lightning, but note the first unresolved item'
   tag: fixed
@@ -129,43 +157,56 @@ notes:
   # Beta 5 below.
 - note: 'Ignore (Sub)Thread not working'
   tag: fixed
-  bug: 1565840
+  bugs:
+  - 1565840
   group: 5
 - note: 'Some search engines not working'
   tag: fixed
-  bug: 1566200
+  bugs:
+  - 1566200
   group: 5
 - note: 'Global indexer causing high CPU loads under some circumstances'
   tag: fixed
-  bug: 1362483
+  bugs:
+  - 1362483
   group: 5
 - note: 'Many fixes of UX/UI glitches'
   tag: fixed
   group: 5
-- note: 'Calendar: Mailing lists not expanding when added as invitees. Note the first unresolved item.'
+- note: 'Calendar: Mailing lists not expanding when added as invitees. Note the first unresolved
+    item.'
   tag: fixed
-  bug: 1530213
+  bugs:
+  - 1530213
   group: 5
-- note: 'Calendar: Lightning not updating to corresponding beta 5 version. Workaround: Set preference
-  <code>extensions.lastAppVersion</code> to a value of 67.0 to force a refresh. Check version number in the
-  Add-on Manager afterwards.'
+- note: 'Calendar: Lightning not updating to corresponding beta 5 version. Workaround:
+    Set preference <code>extensions.lastAppVersion</code> to a value of 67.0 to force a
+    refresh. Check version number in the Add-on Manager afterwards.'
   tag: unresolved
-  bug: 1562573
-- note: 'Thunderbird 68 beta may not recognise an existing profile. Workaround: start with the profile manager option -p.'
+  bugs:
+  - 1562573
+- note: 'Thunderbird 68 beta may not recognise an existing profile. Workaround: start with
+    the profile manager option -p.'
   tag: unresolved
-  bug: 1542025
+  bugs:
+  - 1542025
 - note: 'The spellchecker may mark words preceding a single quote as misspelled'
   tag: unresolved
-  bug: 1565919
+  bugs:
+  - 1565919
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
-- note: 'Calendar: A localized version of Provider for Google Calendar not available at addons.thunderbird.net or
-    the Mozilla FTP server. A US-English version can be downloaded [here](https://queue.taskcluster.net/v1/task/BwwaMEyrRVm-vIh0Pa9Cdg/runs/0/artifacts/public/build/gdata-provider.en-US.xpi).
+  bugs:
+  - 1512812
+- note: 'Calendar: A localized version of Provider for Google Calendar not available at
+    addons.thunderbird.net or the Mozilla FTP server. A US-English version can be downloaded
+    [here](https://queue.taskcluster.net/v1/task/BwwaMEyrRVm-vIh0Pa9Cdg/runs/0/artifacts/public/build/gdata-provider.en-US.xpi).
     The XPI file needs to be installed manually in Thunderbird.'
   tag: unresolved
-  bug: 1516816
+  bugs:
+  - 1516816
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/beta/69.0beta.yml
+++ b/beta/69.0beta.yml
@@ -1,119 +1,141 @@
 release:
   release_date: 2019-07-26
-  text: "**These release notes apply to Thunderbird version 69 beta 4 released August 28th, 2019.**"
+  text: "**These release notes apply to Thunderbird version 69 beta 4 released August 28th,\
+    \ 2019.**"
   import_system_requirements: '68.0'
   groups:
-    -
-    - "Fixed in Beta 2"
-    - "Fixed in Beta 3"
-    - "New and Fixed in Beta 4"
+  - 
+  - "Fixed in Beta 2"
+  - "Fixed in Beta 3"
+  - "New and Fixed in Beta 4"
 
 notes:
-- note: 'While Thunderbird was in safe mode, the help menu did not offer an item to restart with add-ons enabled'
+- note: 'While Thunderbird was in safe mode, the help menu did not offer an item to restart
+    with add-ons enabled'
   tag: fixed
-  bug: 724963
+  bugs:
+  - 724963
   # Beta 2 below.
 - note: 'Chat text input area had near zero height (in beta 1)'
   tag: fixed
-  bug: 1564443
+  bugs:
+  - 1564443
   group: 2
 - note: 'Links on Help menu not working (in beta 1)'
   tag: fixed
-  bug: 1570586
+  bugs:
+  - 1570586
   group: 2
 - note: 'New email notification not properly formatted in some cases'
   tag: fixed
-  bug: 1569129
+  bugs:
+  - 1569129
   group: 2
 - note: 'F6 focus in address book not correct'
   tag: fixed
-  bug: 1546650
+  bugs:
+  - 1546650
   group: 2
 - note: 'Some visual glitches: Wrong colors, backgrounds, tooltips, etc.'
   tag: fixed
-  bug: 1569399
-  bug2: 1569670
-  bug3: 1567770
-  bug4: 1534114
+  bugs:
+  - 1569399
+  - 1569670
+  - 1567770
+  - 1534114
   group: 2
   # Beta 3 below.
 - note: 'Column choice and sort order in "Search Messages" dialog lost after relaunch'
   tag: fixed
-  bug: 297251
+  bugs:
+  - 297251
   group: 3
 - note: 'Theme installation not working via the Add-on Manager (in beta 1 and 2)'
   tag: fixed
-  bug: 1572827
+  bugs:
+  - 1572827
   group: 3
-- note: 'The spellchecker marked words preceding a single quote as misspelled (in beta 2)'
+- note: 'The spellchecker marked words preceding a single quote as misspelled (in beta
+    2)'
   tag: fixed
-  bug: 1565919
+  bugs:
+  - 1565919
   group: 3
-- note: 'More visual glitches: Attachment pane height, link color for detached/external attachments,
-    dark theme, compose window toolbar, error console window title'
+- note: 'More visual glitches: Attachment pane height, link color for detached/external
+    attachments, dark theme, compose window toolbar, error console window title'
   tag: fixed
-  bug: 1571663
-  bug2: 1572106
-  bug3: 1571634
-  bug4: 1527551
-  bug5: 1524255
-  bug6: 1567783
+  bugs:
+  - 1571663
+  - 1572106
+  - 1571634
+  - 1527551
+  - 1524255
+  - 1567783
   group: 3
   # Beta 4 below.
-- note: 'Offer to configure Exchange accounts for Office365.
-    A third-party add-on is required for this account type.
-    IMAP still exists as alternative.'
+- note: 'Offer to configure Exchange accounts for Office365. A third-party add-on is required
+    for this account type. IMAP still exists as alternative.'
   tag: new
-  bug: 1571772
+  bugs:
+  - 1571772
   group: 4
 - note: 'LDAP address auto-complete and server preference not working'
   tag: fixed
-  bug: 1574590
+  bugs:
+  - 1574590
   group: 4
-- note: 'Even more visual glitches: Scrollbar in chat account settings,
-    missing context menu in contacts sidebar, missing chat participant tooltip,
-    icon sizes in toolbars, selection of tagged messages using dark theme,
-    message pane toggle in application menu'
+- note: 'Even more visual glitches: Scrollbar in chat account settings, missing context
+    menu in contacts sidebar, missing chat participant tooltip, icon sizes in toolbars,
+    selection of tagged messages using dark theme, message pane toggle in application menu'
   tag: fixed
-  bug: 1529295
-  bug2: 1574724
-  bug3: 1570679
-  bug4: 1574859
-  bug5: 1575487
-  bug6: 1576397
+  bugs:
+  - 1529295
+  - 1574724
+  - 1570679
+  - 1574859
+  - 1575487
+  - 1576397
   group: 4
-- note: 'Links containing a #reference don''t open correctly in the external browser.
-    External browser may open in a background window.'
+- note: 'Links containing a #reference don''t open correctly in the external browser. External
+    browser may open in a background window.'
   tag: fixed
-  bug: 1573051
-  bug2: 1572970
+  bugs:
+  - 1573051
+  - 1572970
   group: 4
 - note: 'Clicking mailto links in browser doesn''t open Thunderbird Write window'
   tag: unresolved
-  bug: 1577706
+  bugs:
+  - 1577706
 - note: 'Opening the properties of a folder may hang on Mac'
   tag: unresolved
-  bug: 1574322
+  bugs:
+  - 1574322
 - note: 'Mail header toolbar (Reply, Forward, Archive, Junk buttons) no longer configurable'
   tag: unresolved
-  bug: 1535265
-  bug2: 1553427
-  bug3: 1556261
+  bugs:
+  - 1535265
+  - 1553427
+  - 1556261
 # restore the following item for further betas.
 # - note: 'Calendar: Lightning not updating to corresponding beta NN version. Workaround: Set preference
   # <code>extensions.lastAppVersion</code> to a value of 68.0 to force a refresh. Check version number in the
   # Add-on Manager afterwards.'
   # tag: unresolved
   # bug: 1562573
-- note: 'Thunderbird 69 beta may not recognise an existing profile. Workaround: start with the profile manager option -p.'
+- note: 'Thunderbird 69 beta may not recognise an existing profile. Workaround: start with
+    the profile manager option -p.'
   tag: unresolved
-  bug: 1542025
-- note: 'Calendar: A localized version of Provider for Google Calendar not available at addons.thunderbird.net or
-    the Mozilla FTP server. A US-English version can be downloaded
+  bugs:
+  - 1542025
+- note: 'Calendar: A localized version of Provider for Google Calendar not available at
+    addons.thunderbird.net or the Mozilla FTP server. A US-English version can be downloaded
     [here](http://ftp.mozilla.org/pub/thunderbird/releases/69.0b2/en-US/gdata-provider.en-US.xpi).
     The XPI file needs to be installed manually in Thunderbird.'
   tag: unresolved
-  bug: 1516816
+  bugs:
+  - 1516816
 - note: 'Chat: Twitter not working due to API changes at Twitter.com.'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/beta/70.0beta.yml
+++ b/beta/70.0beta.yml
@@ -33,7 +33,7 @@ notes:
     Note that manual installation of add-ons via drag-and-drop currently doesn''t work.'
   tag: changed
   bug: 1565180
-  bug: 1566347
+  bug2: 1566347
 - note: 'Gmail accounts ignored a non-standard trash folder selection.
     Note: If non-standard trash folder was selected previously in the account settings,
     this setting will now take effect which may be unexpected.'
@@ -88,7 +88,7 @@ notes:
   tag: fixed
   bug: 1579411
   bug2: 1577310
-  bug2: 1577591
+  bug3: 1577591
   group: 2
 - note: 'Contrast between tag label and background not optimal'
   tag: fixed
@@ -123,7 +123,7 @@ notes:
   bug2: 1584697
   bug3: 1582830
   bug4: 1585300
-  bug4: 1584487
+  bug5: 1584487
   group: 3
 - note: 'Some attachments couldn''t be opened in messages originating from MS Outlook 2016'
   tag: fixed
@@ -152,7 +152,7 @@ notes:
 - note: 'Calendar: Glitches with custom repeat and reminder number input'
   tag: fixed
   bug: 1583340
-  bug: 1583098
+  bug2: 1583098
   group: 3
 - note: 'Calendar: Problems with WCAP provider'
   tag: fixed

--- a/beta/70.0beta.yml
+++ b/beta/70.0beta.yml
@@ -1,186 +1,229 @@
 release:
   release_date: 2019-09-09
-  text: "**These release notes apply to Thunderbird version 70 beta 4 released October 17th, 2019.**"
+  text: "**These release notes apply to Thunderbird version 70 beta 4 released October\
+    \ 17th, 2019.**"
   import_system_requirements: '68.0'
   groups:
-    -
-    - "Fixed in Beta 2"
-    - "Fixed in Beta 3"
-    - "Fixed in Beta 4"
+  - 
+  - "Fixed in Beta 2"
+  - "Fixed in Beta 3"
+  - "Fixed in Beta 4"
 
 notes:
-- note: 'Allow selecting messages via selection boxes instead of classic selection.
-    "Select Messages" column needs to be selected via the thread pane''s column picker.'
+- note: 'Allow selecting messages via selection boxes instead of classic selection. "Select
+    Messages" column needs to be selected via the thread pane''s column picker.'
   tag: new
-  bug: 1017904
-- note: 'Message Display MailExtensions API with documentation
-    [here](https://thunderbird-webextensions.readthedocs.io/en/latest/messageDisplay.html)'
+  bugs:
+  - 1017904
+- note: 'Message Display MailExtensions API with documentation [here](https://thunderbird-webextensions.readthedocs.io/en/latest/messageDisplay.html)'
   tag: new
-  bug: 1575708
+  bugs:
+  - 1575708
 - note: 'Thunderbird Options/Preferences tab redesigned and with new user interface'
   tag: changed
-  bug: 1498332
+  bugs:
+  - 1498332
 - note: 'Account creation dialog redesigned and with new user interface'
   tag: changed
-  bug: 1551133
+  bugs:
+  - 1551133
 - note: 'Dialog for folder compaction (purging of deleted messages)'
   tag: changed
-  bug: 716412
-- note: 'Thread pane column picker stays open for selecting multiple columns until user clicks outside or hits escape'
+  bugs:
+  - 716412
+- note: 'Thread pane column picker stays open for selecting multiple columns until user
+    clicks outside or hits escape'
   tag: changed
-  bug: 545906
-- note: 'Add-ons manager with new user interface and notifications.
-    Note that manual installation of add-ons via drag-and-drop currently doesn''t work.'
+  bugs:
+  - 545906
+- note: 'Add-ons manager with new user interface and notifications. Note that manual installation
+    of add-ons via drag-and-drop currently doesn''t work.'
   tag: changed
-  bug: 1565180
-  bug2: 1566347
-- note: 'Gmail accounts ignored a non-standard trash folder selection.
-    Note: If non-standard trash folder was selected previously in the account settings,
-    this setting will now take effect which may be unexpected.'
+  bugs:
+  - 1565180
+  - 1566347
+- note: 'Gmail accounts ignored a non-standard trash folder selection. Note: If non-standard
+    trash folder was selected previously in the account settings, this setting will now
+    take effect which may be unexpected.'
   tag: fixed
-  bug: 1578148
+  bugs:
+  - 1578148
 - note: 'Edit tag not working'
   tag: fixed
-  bug: 1578148
+  bugs:
+  - 1578148
 - note: 'Write window: "Insert > Characters and Symbols" not working'
   tag: fixed
-  bug: 1578300
+  bugs:
+  - 1578300
 - note: 'Moving/dragging messages from "Search Messages" result dialog not working'
   tag: fixed
-  bug: 1577987
-  bug2: 1577970
+  bugs:
+  - 1577987
+  - 1577970
 - note: 'Command line -compose "attachment=" not working'
   tag: fixed
-  bug: 1577117
+  bugs:
+  - 1577117
 - note: 'Custom views not working'
   tag: fixed
-  bug: 1578029
+  bugs:
+  - 1578029
 - note: 'Issues with list of content types/actions for incoming attachments'
   tag: fixed
-  bug: 1576950
-  bug2: 1576825
-  bug3: 1578591
+  bugs:
+  - 1576950
+  - 1576825
+  - 1578591
 - note: 'Clicking mailto links in browser doesn''t open Thunderbird Write window'
   tag: fixed
-  bug: 1577706
+  bugs:
+  - 1577706
 - note: '"Learn More" links in Error Console not working'
   tag: fixed
-  bug: 1427590
-- note: 'Visual glitches: Quick Filter Bar tag buttons too tall,
-    missing scroll bar on Connection Setting subdialog,
-    LDAP server selection after "New", "Edit" and "Delete"'
+  bugs:
+  - 1427590
+- note: 'Visual glitches: Quick Filter Bar tag buttons too tall, missing scroll bar on
+    Connection Setting subdialog, LDAP server selection after "New", "Edit" and "Delete"'
   tag: fixed
-  bug: 1577582
-  bug2: 1577259
-  bug3: 1576365
+  bugs:
+  - 1577582
+  - 1577259
+  - 1576365
 - note: 'Calendar: Parts of CalDAV dialog not working'
   tag: fixed
-  bug: 1577989
+  bugs:
+  - 1577989
 - note: 'Calendar: Free/busy information in attendees dialog not loaded'
   tag: fixed
-  bug: 1578196
+  bugs:
+  - 1578196
 # Beta 2 below.
 - note: 'Issues with attachments in IMAP messages'
   tag: fixed
-  bug: 1579341
+  bugs:
+  - 1579341
   group: 2
 - note: 'Various theme fixes, especially dark theme improvements for Calendar'
   tag: fixed
-  bug: 1579411
-  bug2: 1577310
-  bug3: 1577591
+  bugs:
+  - 1579411
+  - 1577310
+  - 1577591
   group: 2
 - note: 'Contrast between tag label and background not optimal'
   tag: fixed
-  bug: 1579364
+  bugs:
+  - 1579364
   group: 2
 - note: 'Accepting auto-complete results via click didn''t move to the next line'
   tag: fixed
-  bug: 1580950
+  bugs:
+  - 1580950
   group: 2
 - note: 'Account Central pane always loaded at start-up'
   tag: fixed
-  bug: 1579575
+  bugs:
+  - 1579575
   group: 2
 - note: 'Setting a contact photo in the addressbook not working'
   tag: fixed
-  bug: 1581253
+  bugs:
+  - 1581253
   group: 2
 - note: 'Manual installation of add-ons via drag & drop onto the Add-ons Manager not working'
   tag: fixed
-  bug: 1566347
+  bugs:
+  - 1566347
   group: 2
 - note: '"Config Editor" button not removed if blocked by policy'
   tag: fixed
-  bug: 1579019
+  bugs:
+  - 1579019
   group: 2
 # Beta 3 below.
-- note: 'Visual glitches: Missing context menu in filter, downloads and password manager dialogs,
-    unwanted scrollbars and cut-off text in Account Manager,
-    incorrect colors in Calendar MiniMonth and agenda scrollbars, theme issues on Windows 7'
+- note: 'Visual glitches: Missing context menu in filter, downloads and password manager
+    dialogs, unwanted scrollbars and cut-off text in Account Manager, incorrect colors
+    in Calendar MiniMonth and agenda scrollbars, theme issues on Windows 7'
   tag: fixed
-  bug: 1584720
-  bug2: 1584697
-  bug3: 1582830
-  bug4: 1585300
-  bug5: 1584487
+  bugs:
+  - 1584720
+  - 1584697
+  - 1582830
+  - 1585300
+  - 1584487
   group: 3
 - note: 'Some attachments couldn''t be opened in messages originating from MS Outlook 2016'
   tag: fixed
-  bug: 1584383
+  bugs:
+  - 1584383
   group: 3
 - note: 'Address book import form CSV'
   tag: fixed
-  bug: 1584026
+  bugs:
+  - 1584026
   group: 3
 - note: 'Performance problem in message body search'
   tag: fixed
-  bug: 1584558
+  bugs:
+  - 1584558
   group: 3
-- note: 'Ctrl+Enter to send a message would open an attachment if the attachment pane had focus'
+- note: 'Ctrl+Enter to send a message would open an attachment if the attachment pane had
+    focus'
   tag: fixed
-  bug: 1578450
+  bugs:
+  - 1578450
   group: 3
 - note: 'Template selection for "Reply with Template"'
   tag: fixed
-  bug: 1584122
+  bugs:
+  - 1584122
   group: 3
 - note: 'Calendar: Issues with "Today Pane" start-up'
   tag: fixed
-  bug: 1582746
+  bugs:
+  - 1582746
   group: 3
 - note: 'Calendar: Glitches with custom repeat and reminder number input'
   tag: fixed
-  bug: 1583340
-  bug2: 1583098
+  bugs:
+  - 1583340
+  - 1583098
   group: 3
 - note: 'Calendar: Problems with WCAP provider'
   tag: fixed
-  bug: 1582746
+  bugs:
+  - 1582746
   group: 3
 # Beta 4 below.
 - note: 'Better visual feedback for unread messages when using the dark theme'
   tag: fixed
-  bug: 1588000
+  bugs:
+  - 1588000
   group: 4
 - note: 'Various issues when editing mailing lists'
   tag: fixed
-  bug: 1584211
-  bug2: 1587587
+  bugs:
+  - 1584211
+  - 1587587
   group: 4
-- note: 'Integration with macOS addressbook and notifications not working after introduction of notarization'
+- note: 'Integration with macOS addressbook and notifications not working after introduction
+    of notarization'
   tag: fixed
-  bug: 1586617
+  bugs:
+  - 1586617
   group: 4
 # restore the following item for further betas.
-- note: 'Calendar: Lightning not updating to corresponding 70.0b4 version. Workaround: Set preference
-    <code>extensions.lastAppVersion</code> to a value of 69.0 to force a refresh. Check version number in the
-    Add-on Manager afterwards.'
+- note: 'Calendar: Lightning not updating to corresponding 70.0b4 version. Workaround:
+    Set preference <code>extensions.lastAppVersion</code> to a value of 69.0 to force a
+    refresh. Check version number in the Add-on Manager afterwards.'
   tag: unresolved
-  bug: 1562573
+  bugs:
+  - 1562573
 - note: 'Opening the properties of a folder may hang on Mac'
   tag: unresolved
-  bug: 1574322
+  bugs:
+  - 1574322
 # gData not hosted by Thunderbird any more
 # - note: 'Calendar: A localized version of Provider for Google Calendar not available at addons.thunderbird.net or
   # the Mozilla FTP server. A US-English version can be downloaded
@@ -190,4 +233,5 @@ notes:
   # bug: 1516816
 - note: 'Chat: Twitter not working due to API changes at Twitter.com.'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/beta/71.0beta.yml
+++ b/beta/71.0beta.yml
@@ -1,166 +1,208 @@
 release:
   release_date: 2019-10-26
-  text: "**These release notes apply to Thunderbird version 71 beta 4 released November 29th, 2019.**"
+  text: "**These release notes apply to Thunderbird version 71 beta 4 released November\
+    \ 29th, 2019.**"
   import_system_requirements: '68.0'
   groups:
-    -
-    - "Fixed in Beta 2"
-    - "New, Changed and Fixed in Beta 3"
-    - "Changed and Fixed in Beta 4"
+  - 
+  - "Fixed in Beta 2"
+  - "New, Changed and Fixed in Beta 3"
+  - "Changed and Fixed in Beta 4"
 
 notes:
 - note: '[Message display toolbar action WebExtension API](https://thunderbird-webextensions.readthedocs.io/en/latest/messageDisplayAction.html)'
   tag: new
-  bug: 1531597
+  bugs:
+  - 1531597
 - note: 'Improved "Recent" folder list for "Move to" and "Copy to" in message context menu'
   tag: changed
-  bug: 949135
-- note: 'Address books are now stored as SQLite databases. Existing address books in
-    MAB format (using a Mork database) will be converted.'
+  bugs:
+  - 949135
+- note: 'Address books are now stored as SQLite databases. Existing address books in MAB
+    format (using a Mork database) will be converted.'
   tag: changed
-  bug: 1572324
-  bug2: 1576525
-  bug3: 1581765
-- note: 'Choosing a language for the user interface (multilingual UI) is now enabled
-    (but ATN doesn''t supply language packs for beta versions)'
+  bugs:
+  - 1572324
+  - 1576525
+  - 1581765
+- note: 'Choosing a language for the user interface (multilingual UI) is now enabled (but
+    ATN doesn''t supply language packs for beta versions)'
   tag: changed
-  bug: 1590206
+  bugs:
+  - 1590206
 - note: 'Calendar storage access is now asynchronous to improve performance'
   tag: changed
-  bug: 501689
+  bugs:
+  - 501689
 - note: 'Application windows not maintaining their size after restart'
   tag: fixed
-  bug: 1580420
-- note: 'Selected or unread messages not shown in the correct color in the thread pane (message list) under some circumstances'
+  bugs:
+  - 1580420
+- note: 'Selected or unread messages not shown in the correct color in the thread pane
+    (message list) under some circumstances'
   tag: fixed
-  bug: 1585765
+  bugs:
+  - 1585765
 - note: 'Issues when upgrading from a 32bit version of Thunderbird to a 64bit version.
     Note: If your profile is still not recognised, selected it by visiting about:profiles
     in the Troubleshooting Information.'
   tag: fixed
-  bug: 1587067
+  bugs:
+  - 1587067
 - note: 'When using a language pack, names of standard folders aren''t localized'
   tag: fixed
-  bug: 1575512
+  bugs:
+  - 1575512
 # Beta 2 below.
 - note: 'Problem with Google authentication (OAuth2)'
   tag: fixed
-  bug: 1592407
+  bugs:
+  - 1592407
   group: 2
 - note: 'Incorrect background color for summary view in dark theme with dark system theme'
   tag: fixed
-  bug: 1591531
+  bugs:
+  - 1591531
   group: 2
 - note: 'Mail account setup dialog resizing unexpectedly'
   tag: fixed
-  bug: 1590503
+  bugs:
+  - 1590503
   group: 2
-- note: 'Various visual glitches: Conditions in filter editor not high enough,
-    folder location widget not showing folder name,
-    global POP inbox not showing folder name, problem with menubar customization'
+- note: 'Various visual glitches: Conditions in filter editor not high enough, folder location
+    widget not showing folder name, global POP inbox not showing folder name, problem with
+    menubar customization'
   tag: fixed
-  bug: 1590666
-  bug2: 1590113
-  bug3: 1590851
+  bugs:
+  - 1590666
+  - 1590113
+  - 1590851
   group: 2
 - note: 'Chat: Nickname not highlighted and textual smilies not replaced with emoticons'
   tag: fixed
-  bug: 1591399
+  bugs:
+  - 1591399
   group: 2
-- note: 'Chat: When creating a chat account, some properties, like the password, not saved properly'
+- note: 'Chat: When creating a chat account, some properties, like the password, not saved
+    properly'
   tag: fixed
-  bug: 1591148
+  bugs:
+  - 1591148
   group: 2
 - note: 'Chat: Extended context menu on Instant messaging status dialog (Show Accounts)'
   tag: fixed
-  bug: 1591506
+  bugs:
+  - 1591506
   group: 2
-- note: 'Calendar: Various glitches: Drag and drop of events,
-    multiple identical notifications, toggles in Today Pane,
-    agenda items not styled properly'
+- note: 'Calendar: Various glitches: Drag and drop of events, multiple identical notifications,
+    toggles in Today Pane, agenda items not styled properly'
   tag: fixed
-  bug: 1590505
-  bug2: 1588694
-  bug3: 1590506
-  bug4: 1591553
+  bugs:
+  - 1590505
+  - 1588694
+  - 1590506
+  - 1591553
   group: 2
 # Beta 3 below.
-- note: 'Navigation buttons are now available in content tabs, for example those opened via an add-on search'
+- note: 'Navigation buttons are now available in content tabs, for example those opened
+    via an add-on search'
   tag: new
-  bug: 787683
+  bugs:
+  - 787683
   group: 3
 - note: 'During email account setup the "Configure manually" button is now available immediately'
   tag: changed
-  bug: 1590636
+  bugs:
+  - 1590636
   group: 3
-- note: 'Address book column picker stays open for selecting multiple columns until user clicks outside or hits escape'
+- note: 'Address book column picker stays open for selecting multiple columns until user
+    clicks outside or hits escape'
   tag: changed
-  bug: 1592393
+  bugs:
+  - 1592393
   group: 3
 - note: '"New email" icon in Windows systray changed from in-tray with arrow to envelope'
   tag: changed
-  bug: 1594200
+  bugs:
+  - 1594200
   group: 3
 - note: 'Icons of attachments in the attachment pane of the Write window not always correct'
   tag: fixed
-  bug: 1593280
+  bugs:
+  - 1593280
   group: 3
 - note: 'Contact age calculation in address book not correct'
   tag: fixed
-  bug: 1592536
+  bugs:
+  - 1592536
   group: 3
 - note: 'Toolbar buttons of add-ons in the menubar not shown after startup'
   tag: fixed
-  bug: 1584160
+  bugs:
+  - 1584160
   group: 3
-- note: 'LDAP lookup not working when SSL was enabled. LDAP search not working when
-    "All Address Books" was selected.'
+- note: 'LDAP lookup not working when SSL was enabled. LDAP search not working when "All
+    Address Books" was selected.'
   tag: fixed
-  bug: 1576364
-  bug2: 1593347
+  bugs:
+  - 1576364
+  - 1593347
   group: 3
 - note: 'Chat: Unable to send messages using XMPP'
   tag: fixed
-  bug: 1592505
+  bugs:
+  - 1592505
   group: 3
-- note: 'Chat: Account reordering via drag-and-drop not working on Instant messaging status dialog (Show Accounts)'
+- note: 'Chat: Account reordering via drag-and-drop not working on Instant messaging status
+    dialog (Show Accounts)'
   tag: fixed
-  bug: 1591505
+  bugs:
+  - 1591505
   group: 3
 # Beta 4 below.
-- note: 'In dark theme unread messages no longer shown in blue to distinguish from tagged messages'
+- note: 'In dark theme unread messages no longer shown in blue to distinguish from tagged
+    messages'
   tag: changed
-  bug: 1596702
+  bugs:
+  - 1596702
   group: 4
 - note: 'Poor response time when entering an address for auto-completion'
   tag: fixed
-  bug: 1597163
+  bugs:
+  - 1597163
   group: 4
 - note: 'Dragging contacts from one address book to another sometimes failed'
   tag: fixed
-  bug: 1595059
+  bugs:
+  - 1595059
   group: 4
 - note: 'Scam link confirmation panel not working'
   tag: fixed
-  bug: 1596413
+  bugs:
+  - 1596413
   group: 4
-- note: 'In Write window, the Link Properties dialog wasn''t showing named anchors in context menu'
+- note: 'In Write window, the Link Properties dialog wasn''t showing named anchors in context
+    menu'
   tag: fixed
-  bug: 1593629
+  bugs:
+  - 1593629
   group: 4
 - note: 'Calendar: Start-up failed if the application menu is not on the calendar toolbars'
   tag: fixed
-  bug: 1588516
+  bugs:
+  - 1588516
   group: 4
 # restore the following item for further betas.
-- note: 'Calendar: Lightning not updating to corresponding 71.0b4 version. Workaround: Set preference
-    <code>extensions.lastAppVersion</code> to a value of 70.0 to force a refresh. Check version number in the
-    Add-on Manager afterwards.'
+- note: 'Calendar: Lightning not updating to corresponding 71.0b4 version. Workaround:
+    Set preference <code>extensions.lastAppVersion</code> to a value of 70.0 to force a
+    refresh. Check version number in the Add-on Manager afterwards.'
   tag: unresolved
-  bug: 1562573
+  bugs:
+  - 1562573
 - note: 'Opening the properties of a folder may hang on Mac'
   tag: unresolved
-  bug: 1574322
+  bugs:
+  - 1574322
 # gData not hosted by Thunderbird any more
 # - note: 'Calendar: A localized version of Provider for Google Calendar not available at addons.thunderbird.net or
   # the Mozilla FTP server. A US-English version can be downloaded
@@ -170,4 +212,5 @@ notes:
   # bug: 1516816
 - note: 'Chat: Twitter not working due to API changes at Twitter.com.'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/beta/72.0beta.yml
+++ b/beta/72.0beta.yml
@@ -1,88 +1,110 @@
 release:
   release_date: 2019-12-04
-  text: "**These release notes apply to Thunderbird version 72 beta 3 released January 3rd, 2020.**"
+  text: "**These release notes apply to Thunderbird version 72 beta 3 released January\
+    \ 3rd, 2020.**"
   import_system_requirements: '68.0'
   groups:
-    -
-    - "Fixed in Beta 2"
-    - "Changed and Fixed in Beta 3"
+  - 
+  - "Fixed in Beta 2"
+  - "Changed and Fixed in Beta 3"
 
 notes:
 - note: '[Raw message source available to WebExtensions](https://thunderbird-webextensions.readthedocs.io/en/latest/messages.html#getraw-messageid)'
   tag: new
-  bug: 1525274
+  bugs:
+  - 1525274
 - note: 'Themes can be previewed in the Add-On Manager'
   tag: new
-  bug: 1598903
+  bugs:
+  - 1598903
 - note: 'Icons displaying encrypted and signed emails looked vertically stretched'
   tag: fixed
-  bug: 1598611
+  bugs:
+  - 1598611
 - note: 'WebExtension toolbar icons were displayed too small'
   tag: fixed
-  bug: 1598955
+  bugs:
+  - 1598955
 - note: 'Folder tree and address book tree lacked vibrancy in Mac OS X'
   tag: fixed
-  bug: 1595408
+  bugs:
+  - 1595408
 - note: 'Searching LDAP address book crashed in some circumstances'
   tag: fixed
-  bug: 1601389
+  bugs:
+  - 1601389
   group: 2
 - note: 'Message navigation with backward and forward buttons did not work in some circumstances'
   tag: fixed
-  bug: 533504
-  bug2: 1600500
+  bugs:
+  - 533504
+  - 1600500
   group: 2
 - note: 'Calendar: Last day of long-running events was not shown'
   tag: fixed
-  bug: 1572964
+  bugs:
+  - 1572964
   group: 2
 - note: 'Calendar: Event attendee dialog was not displayed correctly'
   tag: fixed
-  bug: 1596938
+  bugs:
+  - 1596938
   group: 2
 - note: 'Calendar: Tasks due today were not listed in bold'
   tag: fixed
-  bug: 1598885
+  bugs:
+  - 1598885
   group: 2
 - note: 'Various improvements when setting up an account for a Microsoft Exchange server:
-    Now offers IMAP/SMTP if available, better detection for Office 365 accounts; re-run configuration after password change.'
+    Now offers IMAP/SMTP if available, better detection for Office 365 accounts; re-run
+    configuration after password change.'
   tag: changed
-  bug: 1592258
-  bug2: 1598861
-  bug3: 1600954
+  bugs:
+  - 1592258
+  - 1598861
+  - 1600954
   group: 3
-- note: 'After changing view layout, the message display pane showed garbled content under some circumstances'
+- note: 'After changing view layout, the message display pane showed garbled content under
+    some circumstances'
   tag: fixed
-  bug: 265393
+  bugs:
+  - 265393
   group: 3
 - note: 'Certificate Manager not working'
   tag: fixed
-  bug: 1603537
+  bugs:
+  - 1603537
   group: 3
-- note: 'Various theme changes to achieve "pixel perfection": Unread icon, "no results" icon,
-    paragraph format and font selector, background of folder summary tooltip'
+- note: 'Various theme changes to achieve "pixel perfection": Unread icon, "no results"
+    icon, paragraph format and font selector, background of folder summary tooltip'
   tag: fixed
-  bug: 1605612
-  bug2: 1605613
-  bug3: 1606249
-  bug4: 1602941
+  bugs:
+  - 1605612
+  - 1605613
+  - 1606249
+  - 1602941
   group: 3
 - note: 'Chat: For XMPP accounts, no user icons were shown for users with avatar'
   tag: fixed
-  bug: 1592422
+  bugs:
+  - 1592422
   group: 3
 - note: 'Chat: Contact and conversation context menus not working'
   tag: fixed
-  bug: 1601573
+  bugs:
+  - 1601573
   group: 3
-- note: 'Calendar: Lightning not updating to corresponding 72.0b3 version. Workaround: Set preference
-    <code>extensions.lastAppVersion</code> to a value of 71.0 to force a refresh. Check version number in the
-    Add-on Manager afterwards.'
+- note: 'Calendar: Lightning not updating to corresponding 72.0b3 version. Workaround:
+    Set preference <code>extensions.lastAppVersion</code> to a value of 71.0 to force a
+    refresh. Check version number in the Add-on Manager afterwards.'
   tag: unresolved
-  bug: 1562573
+  bugs:
+  - 1562573
 - note: 'Opening the properties of a folder may hang on Mac'
   tag: unresolved
-  bug: 1574322
+  bugs:
+  - 1574322
 - note: 'WebExtension toolbar button badges not displayed'
   tag: unresolved
-  bug: 1599275
+  bugs:
+  - 1599275

--- a/beta/73.0beta.yml
+++ b/beta/73.0beta.yml
@@ -1,120 +1,162 @@
 release:
   release_date: 2020-01-31
-  text: "**These release notes apply to Thunderbird version 73 beta 2 released January 31, 2020.**"
+  text: "**These release notes apply to Thunderbird version 73 beta 2 released January\
+    \ 31, 2020.**"
   import_system_requirements: '68.0'
   groups:
-    -
-    - "New and Fixed in Beta 2"
+  - 
+  - "New and Fixed in Beta 2"
 
 notes:
-- note: 'Redesigned recipient address fields (To, Cc, Bcc) as single-line input fields for multiple addresses instead of one line per address'
+- note: 'Redesigned recipient address fields (To, Cc, Bcc) as single-line input fields
+    for multiple addresses instead of one line per address'
   tag: new
-  bug: 440377
-- note: 'WebExtension messages.update function extended to mark messages as junk or not junk.'
+  bugs:
+  - 440377
+- note: 'WebExtension messages.update function extended to mark messages as junk or not
+    junk.'
   tag: new
-  bug: 1598332
+  bugs:
+  - 1598332
 - note: 'Chat: IRC echo-message capability'
   tag: new
-  bug: 1601102
-- note: 'Offline replication of LDAP address books now uses an SQLite database instead of a Mork database'
+  bugs:
+  - 1601102
+- note: 'Offline replication of LDAP address books now uses an SQLite database instead
+    of a Mork database'
   tag: changed
-  bug: 1606285
+  bugs:
+  - 1606285
 - note: 'Support for creating Mork-based address books removed'
   tag: changed
-  bug: 1606284
+  bugs:
+  - 1606284
 - note: 'TLS 1.0 and 1.1 disabled'
   tag: changed
-  bug: 1606733
+  bugs:
+  - 1606733
 - note: 'Calendar: Web Calendar Access Protocol (WCAP) support removed'
   tag: changed
-  bug: 1579020
+  bugs:
+  - 1579020
 - note: 'Calendar: Task and Event tree colours adjusted for the dark theme'
   tag: changed
-  bug: 1608344
-- note: 'Attachments with one or more spaces in their names couldn''t be opened under some circumstances'
+  bugs:
+  - 1608344
+- note: 'Attachments with one or more spaces in their names couldn''t be opened under some
+    circumstances'
   tag: fixed
-  bug: 1601905
+  bugs:
+  - 1601905
 - note: 'Tags were lost on messages in shared IMAP folders under some circumstances'
   tag: fixed
-  bug: 1596371
+  bugs:
+  - 1596371
 - note: 'Automatic address book conversion from Mork to SQLite failed in some circumstances'
   tag: fixed
-  bug: 1591811
-- note: 'Setting the "Junk" keyword on a message did not clear the "NonJunk" keyword, and vice-versa'
+  bugs:
+  - 1591811
+- note: 'Setting the "Junk" keyword on a message did not clear the "NonJunk" keyword, and
+    vice-versa'
   tag: fixed
-  bug: 1602628
+  bugs:
+  - 1602628
 - note: 'Signing and encryption icons in the composer status bar'
   tag: fixed
-  bug: 1603497
+  bugs:
+  - 1603497
 - note: 'WebExtension messages.update API failed to change message tags in IMAP folders'
   tag: fixed
-  bug: 1605915
+  bugs:
+  - 1605915
 - note: 'Retrieval of S/MIME certificates from LDAP failed'
   tag: fixed
-  bug: 1604773
+  bugs:
+  - 1604773
 - note: 'Incorrect forwarding of HTML messages caused SMTP servers to respond with a timeout'
   tag: fixed
-  bug: 1222046
-- note: 'Calendar: When filtering tasks both by group and by task name, only the task name filter was applied'
+  bugs:
+  - 1222046
+- note: 'Calendar: When filtering tasks both by group and by task name, only the task name
+    filter was applied'
   tag: fixed
-  bug: 1602652
-- note: 'Calendar: Various parts of the calendar UI stopped working when a second Thunderbird window opened'
+  bugs:
+  - 1602652
+- note: 'Calendar: Various parts of the calendar UI stopped working when a second Thunderbird
+    window opened'
   tag: fixed
-  bug: 1608407
+  bugs:
+  - 1608407
 # beta 2 follows
 - note: 'Support for Client Identity IMAP/SMTP Service Extension'
   tag: new
-  bug: 1532388
+  bugs:
+  - 1532388
   group: 2
 - note: 'Support for OAuth 2.0 authentication for POP3 accounts'
   tag: new
-  bug: 1538409
+  bugs:
+  - 1538409
   group: 2
 - note: 'Focus jumping with recipient pills in addressing widget'
   tag: fixed
-  bug: 1603166
+  bugs:
+  - 1603166
   group: 2
 - note: 'To: field shown if the Newsgroup or Follow-up fields were in use'
   tag: fixed
-  bug: 1607526
+  bugs:
+  - 1607526
   group: 2
-- note: 'Address-parsing crash on some IMAP servers when preference mail.imap.use_envelope_cmd was set'
+- note: 'Address-parsing crash on some IMAP servers when preference mail.imap.use_envelope_cmd
+    was set'
   tag: fixed
-  bug: 1609690
+  bugs:
+  - 1609690
   group: 2
 - note: 'In the Write window "Insert > Characters and Symbols" dialog not working'
   tag: fixed
-  bug: 1610746
+  bugs:
+  - 1610746
   group: 2
 - note: 'In the Write window message header fields were not dark in system dark theme'
   tag: fixed
-  bug: 1610927
+  bugs:
+  - 1610927
   group: 2
 - note: 'Calendar: Could not remove color for default categories'
   tag: fixed
-  bug: 1584853
+  bugs:
+  - 1584853
   group: 2
 - note: 'Calendar: Today pane did not retain width between sessions'
   tag: fixed
-  bug: 1610207
+  bugs:
+  - 1610207
   group: 2
 - note: 'Chat: OTR fingerprint verify dialog not working'
   tag: fixed
-  bug: 1611882
+  bugs:
+  - 1611882
   group: 2
 # restore the following item for further betas.
-- note: 'Calendar: Lightning not updating to corresponding 73.0b2 version. Workaround: Set preference
-    <code>extensions.lastAppVersion</code> to a value of 72.0 to force a refresh. Check version number in the
-    Add-on Manager afterwards.'
+- note: 'Calendar: Lightning not updating to corresponding 73.0b2 version. Workaround:
+    Set preference <code>extensions.lastAppVersion</code> to a value of 72.0 to force a
+    refresh. Check version number in the Add-on Manager afterwards.'
   tag: unresolved
-  bug: 1562573
+  bugs:
+  - 1562573
 - note: 'Opening the properties of a folder may hang on Mac'
   tag: unresolved
-  bug: 1574322
+  bugs:
+  - 1574322
 - note: 'WebExtension toolbar button badges not displayed'
   tag: unresolved
-  bug: 1599275
-- note: 'Offline replication of LDAP databases may fail to replace an earlier copy. Workaround: remove or rename
-      any existing database (probably named <code>ldap.sqlite</code>) from your profile before starting replication'
+  bugs:
+  - 1599275
+- note: 'Offline replication of LDAP databases may fail to replace an earlier copy. Workaround:
+    remove or rename any existing database (probably named <code>ldap.sqlite</code>) from
+    your profile before starting replication'
   tag: unresolved
-  bug: 1608304
+  bugs:
+  - 1608304

--- a/beta/74.0beta.yml
+++ b/beta/74.0beta.yml
@@ -12,116 +12,152 @@ release:
     **Thunderbird 74 no longer supports "legacy" extensions.**
   import_system_requirements: '68.0'
   groups:
-    -
-    - "Changed and Fixed in Beta 2"
+  - 
+  - "Changed and Fixed in Beta 2"
 
 notes:
 - note: 'MailExtensions: API to block sending a message from compose window'
   tag: new
-  bug: 1532528
+  bugs:
+  - 1532528
 - note: 'MailExtensions: API to interact with message in compose window'
   tag: new
-  bug: 1590121
-- note: '**Add-on support: As of version 74.0 beta, Thunderbird only supports
-    MailExtensions and MailExtension Experiments.
-    Restartless add-ons and non-restartless legacy add-ons using XUL overlays
-    are no longer supported.**'
+  bugs:
+  - 1590121
+- note: '**Add-on support: As of version 74.0 beta, Thunderbird only supports MailExtensions
+    and MailExtension Experiments. Restartless add-ons and non-restartless legacy add-ons
+    using XUL overlays are no longer supported.**'
   tag: changed
-  bug: 1614237
+  bugs:
+  - 1614237
 - note: 'Calendar: The Lightning calendar add-on is now integrated into Thunderbird'
   tag: changed
-  bug: 1608610
+  bugs:
+  - 1608610
 - note: 'Account Manager moved to a tab'
   tag: changed
-  bug: 1610445
+  bugs:
+  - 1610445
 - note: 'Improved UI of global search results tab'
   tag: changed
-  bug: 1022228
+  bugs:
+  - 1022228
 - note: 'MailExtensions: Allow commands.update() to disable a command'
   tag: changed
-  bug: 1475043
+  bugs:
+  - 1475043
 - note: 'MailExtensions: Allow browser.query.messages to query by tag'
   tag: changed
-  bug: 1600547
-- note: 'MailExtensions: Changed folder enumeration to return tree structure rather than list'
+  bugs:
+  - 1600547
+- note: 'MailExtensions: Changed folder enumeration to return tree structure rather than
+    list'
   tag: changed
-  bug: 1606584
+  bugs:
+  - 1606584
 - note: 'MailExtensions: Exposed message "Junk" status to addons'
   tag: changed
-  bug: 1610457
-- note: 'When copying messages from an IMAP folder to a local folder, offline store wasn''t used'
+  bugs:
+  - 1610457
+- note: 'When copying messages from an IMAP folder to a local folder, offline store wasn''t
+    used'
   tag: fixed
-  bug: 505456
+  bugs:
+  - 505456
 - note: 'SMTP timeout when forwarding message via filter'
   tag: fixed
-  bug: 1222046
+  bugs:
+  - 1222046
 - note: 'Partial updates not working'
   tag: fixed
-  bug: 1410512
+  bugs:
+  - 1410512
 - note: 'Thread collapsed when opening news message in a new window'
   tag: fixed
-  bug: 1526765
-- note: 'Addons not automatically updated to compatible version after upgrade from Thunderbird 60'
+  bugs:
+  - 1526765
+- note: 'Addons not automatically updated to compatible version after upgrade from Thunderbird
+    60'
   tag: fixed
-  bug: 1574183
+  bugs:
+  - 1574183
 - note: 'Opening the properties of a folder sometimes hung on Mac'
   tag: fixed
-  bug: 1574322
-- note: 'Multiple master password prompts. Fixed by prompting for master password at startup time.'
+  bugs:
+  - 1574322
+- note: 'Multiple master password prompts. Fixed by prompting for master password at startup
+    time.'
   tag: fixed
-  bug: 1610390
+  bugs:
+  - 1610390
 - note: 'Offline replication of LDAP databases sometimes failed to replace an earlier copy'
   tag: fixed
-  bug: 1608304
+  bugs:
+  - 1608304
 - note: 'Calendar: Last day of multiple-day event not displayed'
   tag: fixed
-  bug: 1572964
+  bugs:
+  - 1572964
 - note: 'Chat: Avatars not displayed in tooltips'
   tag: fixed
-  bug: 1592422
+  bugs:
+  - 1592422
 
 # beta 2 follows
 - note: 'Thunderbird will now display a popup window when starting up on a new profile'
   tag: changed
-  bug: 1590036
+  bugs:
+  - 1590036
   group: 2
 - note: 'MailExtensions: Action APIs now provide tab and click information'
   tag: changed
-  bug: 1617514
+  bugs:
+  - 1617514
   group: 2
 - note: 'MailExtensions: Allow composeAction to open popups from onBeforeSend'
   tag: changed
-  bug: 1617742
+  bugs:
+  - 1617742
   group: 2
 - note: 'Long subject lines did not wrap in message header'
   tag: fixed
-  bug: 1616764
+  bugs:
+  - 1616764
   group: 2
 - note: 'Account Manager in tab not consistent with Options/Preferences in tab'
   tag: fixed
-  bug: 1613758
+  bugs:
+  - 1613758
   group: 2
-- note: '"Get New Messages for All Accounts" not working for OAuth2-authenticated IMAP accounts'
+- note: '"Get New Messages for All Accounts" not working for OAuth2-authenticated IMAP
+    accounts'
   tag: fixed
-  bug: 1593611
+  bugs:
+  - 1593611
   group: 2
 - note: 'Searching in message bodies led to false negatives under some circumstances in
     quoted-printable encoded HTML bodies'
   tag: fixed
-  bug: 1614796
+  bugs:
+  - 1614796
   group: 2
-- note: 'Calendar: Starting with 74.0 beta 2, building Thunderbird with --enable-calendar is deprecated,
-    and should be removed from your mozconfig file'
+- note: 'Calendar: Starting with 74.0 beta 2, building Thunderbird with --enable-calendar
+    is deprecated, and should be removed from your mozconfig file'
   tag: fixed
-  bug: 1612190
+  bugs:
+  - 1612190
   group: 2
 - note: 'Chat: macOS users were not be able to connect to a server'
   tag: fixed
-  bug: 1615714
+  bugs:
+  - 1615714
   group: 2
 - note: 'WebExtension toolbar button badges not displayed'
   tag: unresolved
-  bug: 1599275
-- note: 'Address auto-completion not working on Mac if the Mac address book is enabled (File > Use Mac OS X Address Book)'
+  bugs:
+  - 1599275
+- note: 'Address auto-completion not working on Mac if the Mac address book is enabled
+    (File > Use Mac OS X Address Book)'
   tag: unresolved
-  bug: 1615468
+  bugs:
+  - 1615468

--- a/beta/75.0beta.yml
+++ b/beta/75.0beta.yml
@@ -12,110 +12,137 @@ release:
     **As of Thunderbird 74, "legacy" extensions are no longer supported.**
   import_system_requirements: '68.0'
   groups:
-  -
+  - 
   - "Fixed in Beta 2"
   - "Changed and Fixed in Beta 3"
 
 notes:
-- note: 'Improvements of recipient pills: Allow incremental selection of recipient pills with Ctrl+A.
-    Added "Move to To/Cc/Bcc" to recipient pill context menu.'
-  bug: 1615917
-  bug2: 1609647
+- note: 'Improvements of recipient pills: Allow incremental selection of recipient pills
+    with Ctrl+A. Added "Move to To/Cc/Bcc" to recipient pill context menu.'
+  bugs:
+  - 1615917
+  - 1609647
   tag: new
 - note: 'MailExtensions: API event for new message notifications'
-  bug: 1599380
+  bugs:
+  - 1599380
   tag: new
 - note: 'MailExtensions: Allow access to message body with browser.compose'
-  bug: 1613534
+  bugs:
+  - 1613534
   tag: changed
 - note: 'Calendar: Hide UI elements when calendars are disabled'
-  bug: 1617786
+  bugs:
+  - 1617786
   tag: changed
 - note: 'Images not rotated when composing a message'
-  bug: 1340927
+  bugs:
+  - 1340927
   tag: fixed
 - note: 'Extra recipients panel not keyboard-accessible'
-  bug: 1612717
+  bugs:
+  - 1612717
   tag: fixed
 - note: 'Address pills created from an LDAP address book appeared in orange'
-  bug: 1609928
+  bugs:
+  - 1609928
   tag: fixed
 - note: 'Searching across multiple address books sometimes returned incomplete results'
-  bug: 1617797
+  bugs:
+  - 1617797
   tag: fixed
 - note: 'Removing contacts from "All Address Books" view sometimes failed'
-  bug: 1619157
+  bugs:
+  - 1619157
   tag: fixed
 - note: '"Verify" button was not always enabled when subscribing to a new feed'
-  bug: 1604873
+  bugs:
+  - 1604873
   tag: fixed
 - note: 'Moving feeds between accounts via drag & drop was failing under some circumstances'
-  bug: 1617268
+  bugs:
+  - 1617268
   tag: fixed
 - note: 'MailExtensions: browser.menus.overrideContext not working'
-  bug: 1608626
+  bugs:
+  - 1608626
   tag: fixed
 - note: 'Calendar: Menus appeared in message windows'
-  bug: 1620123
+  bugs:
+  - 1620123
   tag: fixed
 
 # Beta 2 follows
 - note: 'Accessibility: Status bar was not detected by screenreaders'
-  bug: 1621287
+  bugs:
+  - 1621287
   tag: fixed
   group: 2
 - note: 'MailExtensions: Did not prompt when requesting new permissions'
-  bug: 1620861
+  bugs:
+  - 1620861
   tag: fixed
   group: 2
 - note: 'MailExtensions: Mailing lists did not expand before triggering onBeforeSend'
-  bug: 1619057
+  bugs:
+  - 1619057
   tag: fixed
   group: 2
 - note: 'Calendar: Invitations with embedded null bytes did not always decode correctly'
-  bug: 1623896
+  bugs:
+  - 1623896
   tag: fixed
   group: 2
 - note: "Calendar: Cancelled events didn't show with a line-through"
-  bug: 1621210
+  bugs:
+  - 1621210
   tag: fixed
   group: 2
 - note: 'Chat: Account wizard did not properly save all options'
-  bug: 1622607
+  bugs:
+  - 1622607
   tag: fixed
   group: 2
 
 # Beta 3 follows
 - note: 'Hardware acceleration was disabled by default'
   tag: changed
-  bug: 1623265
+  bugs:
+  - 1623265
   group: 3
-- note: 'Printing did not work. **This is a temporary fix that disables the print
-      progress dialog.**'
+- note: 'Printing did not work. **This is a temporary fix that disables the print progress
+    dialog.**'
   tag: fixed
-  bug: 1620314
+  bugs:
+  - 1620314
   group: 3
 - note: 'Autodiscover: Standard protocols were not given priority over Exchange'
   tag: fixed
-  bug: 1611405
+  bugs:
+  - 1611405
   group: 3
 - note: 'Language packs were not available for download'
   tag: fixed
-  bug: 1625337
+  bugs:
+  - 1625337
   group: 3
 
 - note: 'Print progress dialog is disabled.'
   tag: unresolved
-  bug: 1625299
+  bugs:
+  - 1625299
 - note: 'Message composer not using correct fonts'
   tag: unresolved
-  bug: 1622231
-  bug2: 1625218
-- note: 'Message composer colors are unreadable when using dark mode on macOS
-and Linux. *Workaround: Set the OS to use a Light theme.*'
+  bugs:
+  - 1622231
+  - 1625218
+- note: 'Message composer colors are unreadable when using dark mode on macOS and Linux.
+    *Workaround: Set the OS to use a Light theme.*'
   tag: unresolved
-  bug: 1625837
+  bugs:
+  - 1625837
 - note: 'Unable to export address book'
   tag: unresolved
-  bug: 1624207
+  bugs:
+  - 1624207
 

--- a/beta/76.0beta.yml
+++ b/beta/76.0beta.yml
@@ -6,122 +6,153 @@ release:
     **As of Thunderbird 74, "legacy" extensions are no longer supported.**
   import_system_requirements: '68.0'
   groups:
-  -
+  - 
   - "Fixed in Beta 2"
   - "Changed and Fixed in Beta 3"
 
 notes:
 - note: 'New Account Hub for centralized account setup'
   tag: new
-  bug: 1589005
+  bugs:
+  - 1589005
 - note: 'Minimize to tray support added for Windows'
   tag: new
-  bug: 208923
-  bug2: 1626161
+  bugs:
+  - 208923
+  - 1626161
 - note: 'New config option to anonymize message date header'
   tag: new
-  bug: 1603359
+  bugs:
+  - 1603359
 - note: 'MailExtensions: Add API for managing identities'
   tag: new
-  bug: 1531593
-  bug2: 1617448
+  bugs:
+  - 1531593
+  - 1617448
 - note: 'Thunderbird will now ask for OS account password before displaying saved passwords'
   tag: changed
-  bug: 1622293
+  bugs:
+  - 1622293
 - note: 'Addons page UI refreshed'
   tag: changed
-  bug: 1600923
+  bugs:
+  - 1600923
 - note: 'MailExtensions: Allow experiments to use address book cache'
   tag: changed
-  bug: 1617379
+  bugs:
+  - 1617379
 - note: 'Calendar: Lightning version removed from Thunderbird user agent string'
   tag: changed
-  bug: 1624241
+  bugs:
+  - 1624241
 - note: 'Email addresses sometimes displayed incorrectly in message composer'
   tag: fixed
-  bug: 1526456
+  bugs:
+  - 1526456
 - note: 'Address book improvements: exporting, editing contacts, contact photos'
   tag: fixed
-  bug: 1622642
-  bug2: 1619155
-  bug3: 1624207
-  bug4: 1626167
-  bug5: 1624207
+  bugs:
+  - 1622642
+  - 1619155
+  - 1624207
+  - 1626167
+  - 1624207
 - note: 'Dark theme fixes: message composer, address book, calendar'
   tag: fixed
-  bug: 1622860
-  bug2: 1622695
-  bug3: 1623938
-  bug4: 1624214
-  bug5: 1625300
-  bug6: 1625987
-  bug7: 1622695
+  bugs:
+  - 1622860
+  - 1622695
+  - 1623938
+  - 1624214
+  - 1625300
+  - 1625987
+  - 1622695
 - note: 'Various accessibility fixes: message composer, account setup, attachment pane'
   tag: fixed
-  bug: 1589859
-  bug2: 1620718
-  bug3: 1613284
-  bug4: 1620310
+  bugs:
+  - 1589859
+  - 1620718
+  - 1613284
+  - 1620310
 - note: 'Mailbox format conversion fixes'
   tag: fixed
-  bug: 1515254
-  bug2: 1611897
+  bugs:
+  - 1515254
+  - 1611897
 - note: 'Mailbox quotas not displayed correctly'
   tag: fixed
-  bug: 841906
+  bugs:
+  - 841906
 - note: 'Chat: Add OTR Fingerprint menu was incorrectly shown for IRC channels'
   tag: fixed
-  bug: 1621266
+  bugs:
+  - 1621266
 - note: 'Chat: Renaming contacts in context menu did not work'
   tag: fixed
-  bug: 1622000
+  bugs:
+  - 1622000
 - note: 'Calendar: Task and event dialogs were sometimes too small for their content'
   tag: fixed
-  bug: 1623817
+  bugs:
+  - 1623817
 - note: 'Calendar: Rotated day and week views not displayed correctly'
   tag: fixed
-  bug: 1608765
+  bugs:
+  - 1608765
 
 # Beta 2 follows
 - note: 'Preferences: "Files & Attachments" column headers did not align with content'
   tag: fixed
   group: 2
-  bug: 1628448
-- note: 'Accessibility: Screen readers were reporting too many activities from the status bar'
+  bugs:
+  - 1628448
+- note: 'Accessibility: Screen readers were reporting too many activities from the status
+    bar'
   tag: fixed
   group: 2
-  bug: 1628891
+  bugs:
+  - 1628891
 - note: 'Chat: Multiple OTR system messages were collapsed, resulting in missed notifications'
   tag: fixed
   group: 2
-  bug: 1549938
+  bugs:
+  - 1549938
 
 
 # Beta 3 follows
 - note: 'Removed "Run in Private Windows" section from Addons page'
   tag: changed
   group: 3
-  bug: 1630055
-- note: 'Messages were sometimes sent with a badly formed address when filled from the addressbook'
+  bugs:
+  - 1630055
+- note: 'Messages were sometimes sent with a badly formed address when filled from the
+    addressbook'
   tag: fixed
   group: 3
-  bug: 1629842
-- note: 'MailExtensions: Setting IMAP messages as read with browser.messages.updated failed to persist'
+  bugs:
+  - 1629842
+- note: 'MailExtensions: Setting IMAP messages as read with browser.messages.updated failed
+    to persist'
   tag: fixed
   group: 3
-  bug: 1631184
-- note: 'MailExtensions: Multiple extensions using compose.onBeforeSend could send an email prematurely'
+  bugs:
+  - 1631184
+- note: 'MailExtensions: Multiple extensions using compose.onBeforeSend could send an email
+    prematurely'
   tag: fixed
   group: 3
-  bug: 1631011
+  bugs:
+  - 1631011
 
 - note: 'Print progress dialog is disabled.'
   tag: unresolved
-  bug: 1625299
+  bugs:
+  - 1625299
 - note: 'Message composer not using correct fonts'
   tag: unresolved
-  bug: 1622231
-  bug2: 1625218
+  bugs:
+  - 1622231
+  - 1625218
 
 
 

--- a/beta/77.0beta.yml
+++ b/beta/77.0beta.yml
@@ -9,72 +9,88 @@ release:
     _[#openpgp:mozilla.org](https://chat.mozilla.org/#/room/#openpgp:mozilla.org)_.**
   import_system_requirements: '68.0'
   groups:
-  -
+  - 
   - "New and Fixed in Beta 2"
   - "New and Fixed in Beta 3"
 
 notes:
 - note: 'Native support for OpenPGP encryption'
   tag: new
-  bug: 1628424
+  bugs:
+  - 1628424
 - note: 'DisableSystemAddonUpdate policy added'
   tag: new
-  bug: 1628156
+  bugs:
+  - 1628156
 - note: 'Global Search menu item in app menu'
   tag: new
-  bug: 1356792
+  bugs:
+  - 1356792
 - note: '"Delete" action column in thread pane (message list)'
   tag: new
-  bug: 1626841
+  bugs:
+  - 1626841
 - note: 'Calendar: Added ICS import support to -file command line option'
   tag: new
-  bug: 1583595
+  bugs:
+  - 1583595
 - note: 'MailExtensions: Added composeScripts API'
   tag: new
-  bug: 1630786
+  bugs:
+  - 1630786
 - note: 'Various theme and dark mode improvements'
   tag: changed
-  bug: 1629084
-  bug2: 1627748
-  bug3: 1629515
-  bug4: 1629518
-  bug5: 1630985
-  bug6: 1631779
+  bugs:
+  - 1629084
+  - 1627748
+  - 1629515
+  - 1629518
+  - 1630985
+  - 1631779
 - note: 'MailExtensions: Return a tab object with getComposeDetails'
   tag: changed
-  bug: 1629023
+  bugs:
+  - 1629023
 - note: 'Password display font had characters that were difficult to read'
   tag: fixed
-  bug: 242418
+  bugs:
+  - 242418
 - note: 'Improvements to recipient address pills'
   tag: fixed
-  bug: 1627451
-  bug2: 1630765
-  bug3: 1633287
-  bug4: 1633562
-  bug5: 1629295
+  bugs:
+  - 1627451
+  - 1630765
+  - 1633287
+  - 1633562
+  - 1629295
 - note: 'Calendar: Event printouts were blank'
   tag: fixed
-  bug: 1626391
+  bugs:
+  - 1626391
 - note: 'MailExtensions: browser.runtime.openOptionsPage did not display page'
   tag: fixed
-  bug: 1526802
+  bugs:
+  - 1526802
 - note: 'MailExtensions: Calendar and task tabs did not trigger browser.tabs events'
   tag: fixed
-  bug: 1627556
+  bugs:
+  - 1627556
 
 # Beta 2
 - note: 'Lock icon added next to OTR encrypted chat messages'
   tag: new
-  bug: 1519799
+  bugs:
+  - 1519799
   group: 2
 - note: 'Chat on macOS did not connect to servers'
   tag: fixed
-  bug: 1635734
+  bugs:
+  - 1635734
   group: 2
 - note: 'Global search(Gloda) view was broken'
   tag: fixed
-  bug: 1636500
+  bugs:
+  - 1636500
   group: 2
 
 # Beta 3
@@ -83,28 +99,35 @@ notes:
   group: 3
 - note: 'WebSockets could not be used'
   tag: fixed
-  bug: 1627649
+  bugs:
+  - 1627649
   group: 3
 - note: 'Custom headers added for searching or filtering could not be removed'
   tag: fixed
-  bug: 1631577
+  bugs:
+  - 1631577
   group: 3
 
-- note: 'Older Linux distributions may not have working OpenPGP support when using
-    the official builds'
+- note: 'Older Linux distributions may not have working OpenPGP support when using the
+    official builds'
   tag: unresolved
-  bug: 1634209
+  bugs:
+  - 1634209
 - note: 'Print progress dialog is disabled'
   tag: unresolved
-  bug: 1625299
+  bugs:
+  - 1625299
 - note: 'Message composer not using correct fonts'
   tag: unresolved
-  bug: 1622231
-  bug2: 1625218
+  bugs:
+  - 1622231
+  - 1625218
 - note: 'Addons cannot be removed'
   tag: unresolved
-  bug: 1629459
+  bugs:
+  - 1629459
 - note: 'Anomalies when inserting an image into the compose window'
   tag: unresolved
-  bug: 1636971
+  bugs:
+  - 1636971
 

--- a/beta/78.0beta.yml
+++ b/beta/78.0beta.yml
@@ -1,6 +1,7 @@
 release:
   release_date: 2020-06-16
-  text: "**These release notes apply to Thunderbird version 78 beta 4 released June 29, 2020.**"
+  text: "**These release notes apply to Thunderbird version 78 beta 4 released June 29,\
+    \ 2020.**"
   system_requirements: |
     ## Windows
 
@@ -54,7 +55,7 @@ release:
         - DBus 1.0 or higher
         - GNOME 2.16 or higher
   groups:
-  -
+  - 
   - "New, Changed, and Fixed in Beta 2"
   - "New and Fixed in Beta 3"
   - "New, Changed, and Fixed in Beta 4"
@@ -62,198 +63,245 @@ release:
 notes:
 - note: 'Color customization of Folder Pane icons'
   tag: new
-  bug: 1637668
+  bugs:
+  - 1637668
 - note: 'Additional Enterprise policies'
   tag: new
-  bug: 1622703
+  bugs:
+  - 1622703
 - note: 'Calendar: Add event preview to ICS import dialog'
   tag: new
-  bug: 1631902
+  bugs:
+  - 1631902
 - note: 'OpenPGP support improvements'
   tag: changed
-  bug: 1639683
-  bug2: 1641374
-  bug3: 1638398
-  bug4: 1638537
+  bugs:
+  - 1639683
+  - 1641374
+  - 1638398
+  - 1638537
 - note: 'Various Address Book improvements'
   tag: changed
-  bug: 1633294
-  bug2: 1630184
+  bugs:
+  - 1633294
+  - 1630184
 - note: 'Dark mode improvements'
   tag: changed
-  bug: 1619725
-  bug2: 1640390
+  bugs:
+  - 1619725
+  - 1640390
 - note: 'Use scalable icons throughout Thunderbird'
   tag: changed
-  bug: 1636238
-  bug2: 1638863
+  bugs:
+  - 1636238
+  - 1638863
 - note: 'Account settings UI improvements'
   tag: changed
-  bug: 1628497
+  bugs:
+  - 1628497
 - note: 'MailExtensions: Handle message attachments in browser.compose functions'
   tag: changed
-  bug: 1613535
+  bugs:
+  - 1613535
 - note: 'Calendar: Location URLs are now clickable'
   tag: changed
-  bug: 1614972
+  bugs:
+  - 1614972
 - note: 'Various fixes for recipient address entry'
   tag: fixed
-  bug: 1636393
-  bug2: 1602477
-  bug3: 1640722
+  bugs:
+  - 1636393
+  - 1602477
+  - 1640722
 - note: 'Fixed width font not working in Write window'
   tag: fixed
-  bug: 1622231
+  bugs:
+  - 1622231
 - note: 'Accessibility improvements'
   tag: fixed
-  bug: 1637230
-  bug2: 1637536
+  bugs:
+  - 1637230
+  - 1637536
 - note: 'Attachment pane in message preview layout broke when toggled or resized'
   tag: fixed
-  bug: 1636558
+  bugs:
+  - 1636558
 - note: 'Access key Alt+M for the attachment pane of the Write window not working correctly'
   tag: fixed
-  bug: 1625263
+  bugs:
+  - 1625263
 - note: 'Addons could not be removed'
   tag: fixed
-  bug: 1629459
+  bugs:
+  - 1629459
 
 
 # Beta 2
 - note: 'MailExtensions: browser.identity API enabled'
   tag: new
-  bug: 1644000
+  bugs:
+  - 1644000
   group: 2
 - note: 'MailExtensions: Event fired when the user changes compose identity'
   tag: new
-  bug: 1642189
+  bugs:
+  - 1642189
   group: 2
 
 - note: 'Improvements to the location bar of a tab displaying web pages'
   tag: changed
-  bug: 1644689
+  bugs:
+  - 1644689
   group: 2
 - note: 'Several improvements to vCard parsing'
   tag: changed
-  bug: 1639496
-  bug2: 1643262
+  bugs:
+  - 1639496
+  - 1643262
   group: 2
 - note: 'Various look and feel improvements'
-  bug: 1645700
-  bug2: 1645687
-  bug3: 1644730
-  bug4: 1643159
-  bug5: 1514863
-  bug6: 1645094
-  bug7: 1644798
+  bugs:
+  - 1645700
+  - 1645687
+  - 1644730
+  - 1643159
+  - 1514863
+  - 1645094
+  - 1644798
   tag: changed
   group: 2
 
 - note: 'Print-progress dialog was disabled'
   tag: fixed
-  bug: 1625299
+  bugs:
+  - 1625299
   group: 2
 - note: '"Clear Recent History" window did nothing'
   tag: fixed
-  bug: 1639415
+  bugs:
+  - 1639415
   group: 2
 - note: '"Initially Show Attachment Pane" option was not working for Write window'
   tag: fixed
-  bug: 1634946
+  bugs:
+  - 1634946
   group: 2
-- note: 'Links in the Account Central content tab opened in Thunderbird as well as the browser'
+- note: 'Links in the Account Central content tab opened in Thunderbird as well as the
+    browser'
   tag: fixed
-  bug: 1645271
+  bugs:
+  - 1645271
   group: 2
 - note: 'Order of columns in the thread pane was not persisted correctly'
   tag: fixed
-  bug: 1612055
+  bugs:
+  - 1612055
   group: 2
 - note: 'URLs in the message header display were not reachable via keyboard'
   tag: fixed
-  bug: 1589863
+  bugs:
+  - 1589863
   group: 2
 - note: 'Calendar: URLs in the event reminder dialog were not clickable'
   tag: fixed
-  bug: 1644990
+  bugs:
+  - 1644990
   group: 2
 - note: 'MailExtensions: Extension popup windows opened in a copy of the main window'
   tag: fixed
-  bug: 1644083
+  bugs:
+  - 1644083
   group: 2
 
 
 # Beta 3
 - note: 'Preference to disable OpenPGP functionality'
   tag: new
-  bug: 1645914
+  bugs:
+  - 1645914
   group: 3
 - note: 'MailExtensions: UI components for browser pages added'
   tag: new
-  bug: 1645945
+  bugs:
+  - 1645945
   group: 3
-- note: 'OpenPGP support did not work on some Linux distributions when using the official builds'
+- note: 'OpenPGP support did not work on some Linux distributions when using the official
+    builds'
   tag: fixed
-  bug: 1634209
+  bugs:
+  - 1634209
   group: 3
 - note: 'Thunderbird 78 did not run on Red Hat Linux 7'
   tag: fixed
-  bug: 1646993
+  bugs:
+  - 1646993
+  - 1643258
   group: 3
-  bug2: 1643258
 - note: 'Anomalies appeared when inserting an image into the compose window'
   tag: fixed
-  bug: 1636971
+  bugs:
+  - 1636971
   group: 3
 - note: 'Chat: Copying from chat conversations not working'
   tag: fixed
-  bug: 1611442
+  bugs:
+  - 1611442
   group: 3
 
 
 # Beta 4
 - note: 'Chat: Direct message support for Matrix'
-  bug: 1348064
+  bugs:
+  - 1348064
   tag: new
   group: 4
 - note: 'OpenPGP improvements'
-  bug: 1642795
-  bug2: 1647671
-  bug3: 1646367
-  bug4: 1648957
-  bug5: 1648978
-  bug6: 1638645
+  bugs:
+  - 1642795
+  - 1647671
+  - 1646367
+  - 1648957
+  - 1648978
+  - 1638645
   tag: changed
   group: 4
 - note: 'Various look and feel improvements'
-  bug: 1647479
-  bug2: 1647471
-  bug3: 1648170
+  bugs:
+  - 1647479
+  - 1647471
+  - 1648170
   tag: changed
   group: 4
 - note: 'Addresses added to address book were not inserted into sorted order'
-  bug: 1639750
+  bugs:
+  - 1639750
   tag: fixed
   group: 4
 - note: 'Address book migration not working under certain circumstances'
-  bug: 1647249
+  bugs:
+  - 1647249
   tag: fixed
   group: 4
 - note: 'Chat: Own messages not displayed in private chats when server supports "echo-message"'
-  bug: 1646049
+  bugs:
+  - 1646049
   tag: fixed
   group: 4
-- note: 'MailExtensions: Tab was not defined in browser.menus.onClicked callback on out-of-window messages'
-  bug: 1644487
+- note: 'MailExtensions: Tab was not defined in browser.menus.onClicked callback on out-of-window
+    messages'
+  bugs:
+  - 1644487
   tag: fixed
   group: 4
 - note: 'MailExtensions: Select elements in action popups closed the window unexpectedly'
-  bug: 1627197
+  bugs:
+  - 1627197
   tag: fixed
   group: 4
 
 
 # Unresolved
 - note: 'Preferences search not available'
-  bug: 1573678
+  bugs:
+  - 1573678
   tag: unresolved

--- a/beta/79.0beta.yml
+++ b/beta/79.0beta.yml
@@ -58,7 +58,7 @@ release:
         - GNOME 2.16 or higher
 
   groups:
-  -
+  - 
   - "New and Fixed in Beta 2"
   - "New, Changed, and Fixed in Beta 3"
 
@@ -66,125 +66,161 @@ notes:
 
 - note: 'Date and relevance setting remembered in facet search results'
   tag: new
-  bug: 663859
+  bugs:
+  - 663859
 - note: 'The preferences tab now has a search field'
   tag: new
-  bug: 1573678
+  bugs:
+  - 1573678
 - note: 'Language packs and dictionaries added to about:support'
   tag: new
-  bug: 1648165
+  bugs:
+  - 1648165
 - note: 'Theming improvements to the address book window and dialogs'
   tag: fixed
-  bug: 1649577
-  bug2: 1650789
+  bugs:
+  - 1649577
+  - 1650789
 
-- note: 'FileLink both created a link and attached a file to the message if the file was from a network share'
+- note: 'FileLink both created a link and attached a file to the message if the file was
+    from a network share'
   tag: fixed
-  bug: 793118
+  bugs:
+  - 793118
 - note: 'IMAP fetch chunk size was always 65536 bytes'
   tag: fixed
-  bug: 1580480
+  bugs:
+  - 1580480
 - note: 'Incremental search in contacts side bar failed to return some results'
   tag: fixed
-  bug: 1644026
-- note: 'When deleting a contact from search results in contacts sidebar, the entire result set disappeared'
+  bugs:
+  - 1644026
+- note: 'When deleting a contact from search results in contacts sidebar, the entire result
+    set disappeared'
   tag: fixed
-  bug: 1644084
+  bugs:
+  - 1644084
 - note: 'Crash on failure of LDAP address book replication'
   tag: fixed
-  bug: 1645512
+  bugs:
+  - 1645512
 - note: 'Adaptive Junk Mail settings could not be disabled'
   tag: fixed
-  bug: 1646529
+  bugs:
+  - 1646529
 - note: '"Unresponsive script" error on start-up for profiles with many folders'
   tag: fixed
-  bug: 1647251
+  bugs:
+  - 1647251
 - note: 'OAuth authorization window was missing the URL bar'
   tag: fixed
-  bug: 1649423
+  bugs:
+  - 1649423
 
 
 # Beta 2
 - note: 'OpenPGP: Key revocation, extending key expiration, and secret key backup'
   tag: new
-  bug: 1651712
+  bugs:
+  - 1651712
   group: 2
 - note: 'Drag & Drop multiple attachments to macOS Finder created duplicate files'
   tag: fixed
-  bug: 1494588
+  bugs:
+  - 1494588
   group: 2
 - note: 'About Thunderbird dialog keyboard shortcuts did not work'
   tag: fixed
-  bug: 1638563
+  bugs:
+  - 1638563
   group: 2
 - note: 'CC''d recipients sometimes displayed collapsed in header pane'
   tag: fixed
-  bug: 1652410
+  bugs:
+  - 1652410
   group: 2
 - note: 'Message filter and Folder Pane dialogs did not use the correct theme'
   tag: fixed
-  bug: 1650791
-  bug2: 1652015
+  bugs:
+  - 1650791
+  - 1652015
   group: 2
 - note: 'Changing Junk mail settings with keyboard toggled wrong setting'
   tag: fixed
-  bug: 1607613
+  bugs:
+  - 1607613
   group: 2
 - note: 'OpenPGP: Messages with long Armor Header lines did not display'
   tag: fixed
-  bug: 1653651
+  bugs:
+  - 1653651
   group: 2
 - note: 'OpenPGP: Messages containing non-UTF-8 text were not supported'
   tag: fixed
-  bug: 1651896
+  bugs:
+  - 1651896
   group: 2
 - note: 'Address book migration updates and fixes'
   tag: fixed
-  bug: 1652940
+  bugs:
+  - 1652940
   group: 2
 - note: 'Address book: Last Modified Date was not updated'
   tag: fixed
-  bug: 1634863
+  bugs:
+  - 1634863
   group: 2
 - note: 'Chat: Participants list did not display operator flags'
   tag: fixed
-  bug: 1648585
+  bugs:
+  - 1648585
   group: 2
 
 # Beta 3
-- note: '**OpenPGP support is now feature complete.** Improvements: new Key Wizard, online searching for OpenPGP keys, and more'
+- note: '**OpenPGP support is now feature complete.** Improvements: new Key Wizard, online
+    searching for OpenPGP keys, and more'
   tag: new
-  bug: 22687
-  bug2: 1652537
-  bug3: 1655113
+  bugs:
+  - 22687
+  - 1652537
+  - 1655113
   group: 3
 - note: 'Dark background in message reader is now disabled'
   tag: changed
-  bug: 1639249
+  bugs:
+  - 1639249
   group: 3
-- note: 'Attachment corruption could occur when downloading large attachments from an IMAP server that supports chunking'
+- note: 'Attachment corruption could occur when downloading large attachments from an IMAP
+    server that supports chunking'
   tag: fixed
-  bug: 1654995
+  bugs:
+  - 1654995
   group: 3
-- note: 'Thunderbird startup was slow when using folder color customizations with many folders. **Previously configured colors will not be migrated.**'
+- note: 'Thunderbird startup was slow when using folder color customizations with many
+    folders. **Previously configured colors will not be migrated.**'
   tag: fixed
-  bug: 1652279
+  bugs:
+  - 1652279
   group: 3
 - note: 'Mail quota usage in status bar did not support terabyte folder sizes'
-  bug: 1636665
+  bugs:
+  - 1636665
   tag: fixed
   group: 3
 - note: 'Dark mode improvements'
   tag: fixed
-  bug: 1653751
-  bug2: 1653750
+  bugs:
+  - 1653751
+  - 1653750
   group: 3
 
 
 
 - note: 'Chat displays no messages'
   tag: unresolved
-  bug: 1646611
+  bugs:
+  - 1646611
 - note: 'Fixed width font not working in compose window'
   tag: unresolved
-  bug: 1655279
+  bugs:
+  - 1655279

--- a/beta/80.0beta.yml
+++ b/beta/80.0beta.yml
@@ -12,191 +12,231 @@ release:
   import_system_requirements: '79.0beta'
 
   groups:
-  -
+  - 
   - "Changed and Fixed in Beta 2"
   - "Changed and Fixed in Beta 3"
   - "Fixed in Beta 4"
   - "Changed and Fixed in Beta 5"
 
 notes:
-- note: '**OpenPGP support is now feature complete.** Improvements: new Key Wizard,
-      online searching for OpenPGP keys, and more'
+- note: '**OpenPGP support is now feature complete.** Improvements: new Key Wizard, online
+    searching for OpenPGP keys, and more'
   tag: new
-  bug: 22687
-  bug2: 1652537
-  bug3: 1655113
+  bugs:
+  - 22687
+  - 1652537
+  - 1655113
 
 - note: '"Master Password" renamed to "Primary Password"'
   tag: changed
-  bug: 1649522
+  bugs:
+  - 1649522
 - note: 'Twitter search removed'
   tag: changed
-  bug: 1653792
+  bugs:
+  - 1653792
 - note: 'Building OpenPGP shared library linked to system libraries now supported'
   tag: changed
-  bug: 1634963
+  bugs:
+  - 1634963
 - note: 'MailExtension errors now shown in Developer Tools console by default'
   tag: changed
-  bug: 1650149
+  bugs:
+  - 1650149
 
 
 
 - note: 'IMAP server capabilities were not rechecked after upgrading to SSL/TLS connection'
   tag: fixed
-  bug: 1611624
+  bugs:
+  - 1611624
 - note: 'Advanced IMAP server preferences not saved in Account Manager'
   tag: fixed
-  bug: 1653588
+  bugs:
+  - 1653588
 - note: 'Message preview was sometimes blank after upgrading from Thunderbird 68'
   tag: fixed
-  bug: 1653168
+  bugs:
+  - 1653168
 - note: 'Address Book UI improvements'
   tag: fixed
-  bug: 1632331
-  bug2: 1659522
+  bugs:
+  - 1632331
+  - 1659522
 - note: 'Drag and drop of address book contacts did not work in some situations'
-  bug: 1649804
+  bugs:
+  - 1649804
   tag: fixed
 - note: 'Email addresses whitelisted for remote content not displayed in preferences'
-  bug: 1652575
+  bugs:
+  - 1652575
   tag: fixed
 
 
 # Beta 2 follows
 - note: 'Building OpenPGP shared library linked to system libraries now supported'
   tag: changed
-  bug: 1634963
+  bugs:
+  - 1634963
   group: 2
 - note: 'MailExtensions: Dynamic registration of calendar providers now supported'
   tag: changed
-  bug: 1652885
+  bugs:
+  - 1652885
   group: 2
 
 - note: 'OpenPGP bug fixes and improvements'
   tag: fixed
-  bug: 1633251
-  bug2: 1653763
-  bug3: 1656023
-  bug4: 1656391
-  bug5: 1657245
-  bug6: 1657464
+  bugs:
+  - 1633251
+  - 1653763
+  - 1656023
+  - 1656391
+  - 1657245
+  - 1657464
   group: 2
 - note: 'Address book migration failed when there was a dot in the file name'
   tag: fixed
-  bug: 1655686
+  bugs:
+  - 1655686
   group: 2
 - note: 'Address book: "Always prefer display name over message header" was always checked
     when editing a contact'
   tag: fixed
-  bug: 1655884
+  bugs:
+  - 1655884
   group: 2
 - note: 'Printing did not always work'
   tag: fixed
-  bug: 1654548
+  bugs:
+  - 1654548
   group: 2
-- note: '"Select All" (Ctrl+A) in message source did not work until focused with a mouse click'
+- note: '"Select All" (Ctrl+A) in message source did not work until focused with a mouse
+    click'
   tag: fixed
-  bug: 1657619
+  bugs:
+  - 1657619
   group: 2
 - note: 'Ctrl+scroll wheel not zooming in message reader'
   tag: fixed
-  bug: 1655244
+  bugs:
+  - 1655244
   group: 2
 - note: 'Chat did not display messages'
   tag: fixed
-  bug: 1646611
+  bugs:
+  - 1646611
   group: 2
 - note: 'Setting/changing a signature from a file lost when closing account settings'
   tag: fixed
-  bug: 1657050
+  bugs:
+  - 1657050
   group: 2
 - note: 'Message filter dialog fixes: Missing scrollbar, drop-down list not wide enough'
   tag: fixed
-  bug: 1633306
-  bug2: 1656648
+  bugs:
+  - 1633306
+  - 1656648
   group: 2
 - note: 'Various UX and theme improvements'
   tag: fixed
-  bug: 1655568
-  bug2: 1655573
-  bug3: 1655289
-  bug4: 656113
+  bugs:
+  - 1655568
+  - 1655573
+  - 1655289
+  - 656113
   group: 2
 
 
 # Beta 3
 - note: 'OpenPGP Key generation now disabled when there is no default mail account configured'
   tag: changed
-  bug: 1657497
+  bugs:
+  - 1657497
   group: 3
-- note: 'MailExtensions: Some APIs now use defineLazyPreferenceGetter in order
-      to benefit from caching'
+- note: 'MailExtensions: Some APIs now use defineLazyPreferenceGetter in order to benefit
+    from caching'
   tag: changed
-  bug: 1658116
+  bugs:
+  - 1658116
   group: 3
 
 - note: 'OpenPGP Key Manager search function did not work'
   tag: fixed
-  bug: 1657894
+  bugs:
+  - 1657894
   group: 3
 - note: 'OpenPGP Key Properties dialog was sometimes too small'
   tag: fixed
-  bug: 1643343
+  bugs:
+  - 1643343
   group: 3
 - note: 'Address book performance optimizations'
   tag: fixed
-  bug: 1658062
-  bug2: 1658128
+  bugs:
+  - 1658062
+  - 1658128
   group: 3
 
 
 # Beta 4
 - note: 'OpenPGP: Encrypted email would not send if address contained uppercase characters'
   tag: fixed
-  bug: 1657390
+  bugs:
+  - 1657390
   group: 4
 - note: 'OpenPGP: "Key ID" column could not be resized in Key Manage'
   tag: fixed
-  bug: 1658512
+  bugs:
+  - 1658512
   group: 4
 - note: 'Message Composer: Order of attachments could not be modified using drag & drop'
   tag: fixed
-  bug: 1658114
+  bugs:
+  - 1658114
   group: 4
 - note: 'Address Book: Migration did not preserve names of address books used in filters'
   tag: fixed
-  bug: 1659971
+  bugs:
+  - 1659971
   group: 4
 
 
 # Beta 5
 - note: 'OpenPGP: Encrypted messages are now signed automatically'
   tag: changed
-  bug: 1659487
+  bugs:
+  - 1659487
   group: 5
 - note: 'Calendar: Event summary dialog is now themeable'
   tag: changed
-  bug: 1659079
+  bugs:
+  - 1659079
   group: 5
 
 - note: 'OpenPGP: Keys containing invalid UTF-8 strings could not be imported'
   tag: fixed
-  bug: 1658730
+  bugs:
+  - 1658730
   group: 5
 - note: 'Dialog to add a new mail account from "Account Settings" did not open'
   tag: fixed
-  bug: 1659241
+  bugs:
+  - 1659241
   group: 5
 - note: 'Composing messages with a "fixed width" font did not work'
   tag: fixed
-  bug: 1658999
+  bugs:
+  - 1658999
   group: 5
 
 
 # Unresolved
 - note: 'Thunderbird may become unresponsive when sorting large IMAP folders'
   tag: unresolved
-  bug: 1657565
+  bugs:
+  - 1657565
 - note: 'MailExtensions: Content scripts in mail editor do not work'
   tag: unresolved
-  bug: 1652686
+  bugs:
+  - 1652686

--- a/beta/81.0beta.yml
+++ b/beta/81.0beta.yml
@@ -11,7 +11,7 @@ release:
   import_system_requirements: '79.0beta'
 
   groups:
-  -
+  - 
   - "Changed and Fixed in Beta 2"
   - "New, Changed, and Fixed in Beta 3"
   - "Changed and Fixed in Beta 4"
@@ -19,182 +19,228 @@ release:
 notes:
 - note: 'PDF.js viewer now included in Thunderbird'
   tag: new
-  bug: 810815
+  bugs:
+  - 810815
 
 - note: 'Address book: Synchronization of CardDAV address books now supported'
   tag: changed
-  bug: 1660127
+  bugs:
+  - 1660127
 - note: 'Calendar: Opening an existing event now opens summary dialog'
   tag: changed
-  bug: 1575195
+  bugs:
+  - 1575195
 - note: 'Chat: Image based emoticons replaced with Unicode'
   tag: changed
-  bug: 1658648
+  bugs:
+  - 1658648
 - note: 'Chat: Non-functional Twitter support removed'
   tag: changed
-  bug: 1445778
+  bugs:
+  - 1445778
 - note: 'MailExtensions: messageDisplay APIs extended to support multiple selected messages'
   tag: changed
-  bug: 1617461
+  bugs:
+  - 1617461
 
 
 - note: 'Message list not in focus at startup'
   tag: fixed
-  bug: 1629522
+  bugs:
+  - 1629522
 - note: 'Email filters reported failure when moving a message to original folder'
   tag: fixed
-  bug: 1653690
+  bugs:
+  - 1653690
 - note: 'Sending messages sometimes failed when recipients were in LDAP address book'
   tag: fixed
-  bug: 1371309
+  bugs:
+  - 1371309
 - note: 'Address book: Creating mailing list from contacts sidebar failed'
   tag: fixed
-  bug: 1659162
+  bugs:
+  - 1659162
 - note: 'Address book: Search box icon duplicated after toolbar customization'
   tag: fixed
-  bug: 1650486
+  bugs:
+  - 1650486
 - note: 'vCard 2.1 attachments not handled properly'
   tag: fixed
-  bug: 1659323
-  bug2: 1660134
+  bugs:
+  - 1659323
+  - 1660134
 - note: 'Non-functional help menu items removed'
   tag: fixed
-  bug: 1659318
+  bugs:
+  - 1659318
 - note: 'Calendar: Event reminder details were unreadable'
   tag: fixed
-  bug: 1658923
+  bugs:
+  - 1658923
 
 - note: 'MailExtensions: browser.folders.delete failed on IMAP folders'
   tag: fixed
-  bug: 1651308
+  bugs:
+  - 1651308
 - note: 'MailExtensions: Content scripts in message composer did not work'
   tag: fixed
-  bug: 1652686
+  bugs:
+  - 1652686
 
 
 # Beta 2
 - note: 'OpenPGP enabled by default'
   tag: changed
-  bug: 1659536
+  bugs:
+  - 1659536
   group: 2
 - note: 'OpenPGP: Disabled the use of MD5/SM2/SM3 algorithms'
   tag: changed
-  bug: 1641720
+  bugs:
+  - 1641720
   group: 2
 
-- note: 'OpenPGP: Users with sub-identities were unable to encrypt or sign messages
-  when switching identities'
+- note: 'OpenPGP: Users with sub-identities were unable to encrypt or sign messages when
+    switching identities'
   tag: fixed
-  bug: 1661160
+  bugs:
+  - 1661160
   group: 2
-- note: 'Message filters: Filters shown as enabled in configuration dialog were not always enabled'
+- note: 'Message filters: Filters shown as enabled in configuration dialog were not always
+    enabled'
   tag: fixed
-  bug: 1660917
+  bugs:
+  - 1660917
   group: 2
 - note: 'OpenPGP message security window did not support dark mode'
   tag: fixed
-  bug: 1661203
+  bugs:
+  - 1661203
   group: 2
 - note: 'Thread summaries were unreadable on macOS using dark mode'
   tag: fixed
-  bug: 1660403
+  bugs:
+  - 1660403
   group: 2
-- note: 'Adding custom headers in the addressing widget (preference
-          mail.compose.other.header) did not work'
+- note: 'Adding custom headers in the addressing widget (preference mail.compose.other.header)
+    did not work'
   tag: fixed
-  bug: 1658890
+  bugs:
+  - 1658890
   group: 2
 
 # Beta 3
 - note: 'Drag and Drop reordering of recipient pills now supported'
   tag: new
-  bug: 1601749
+  bugs:
+  - 1601749
   group: 3
 - note: 'Calendar: Remote calendar auto-detection now supported'
   tag: new
-  bug: 306495
+  bugs:
+  - 306495
   group: 3
 - note: 'OpenPGP: Some signature states reported as "mismatch" now report "unknown"'
   tag: changed
-  bug: 1662881
+  bugs:
+  - 1662881
   group: 3
 - note: 'Privacy policy now displayed in a tab when updated'
   tag: changed
-  bug: 1651298
+  bugs:
+  - 1651298
   group: 3
 - note: 'Installation of "legacy" MailExtensions now disabled'
   tag: changed
-  bug: 1661216
+  bugs:
+  - 1661216
   group: 3
 - note: 'OpenPGP: Improvements to key importing when failures occur'
   tag: fixed
-  bug: 1663037
+  bugs:
+  - 1663037
   group: 3
 - note: 'OpenPGP: Decryption did not work with certain HTTP proxy configurations'
   tag: fixed
-  bug: 1661913
+  bugs:
+  - 1661913
   group: 3
-- note: 'OpenPGP: "Discover keys online" option did not work when searching for an email address'
+- note: 'OpenPGP: "Discover keys online" option did not work when searching for an email
+    address'
   tag: fixed
-  bug: 1663157
+  bugs:
+  - 1663157
   group: 3
 - note: 'OpenPGP: Creating a new key pair did not automatically select it for use'
   tag: fixed
-  bug: 1663422
+  bugs:
+  - 1663422
   group: 3
 - note: 'News reader crashed when downloading new articles. See unresolved issues.'
   tag: fixed
-  bug: 1657493
+  bugs:
+  - 1657493
   group: 3
 - note: 'Button to restore default folder icon color was not keyboard accessible'
   tag: fixed
-  bug: 1663075
+  bugs:
+  - 1663075
   group: 3
 - note: 'Windows 10 high-contrast theme fixes'
   tag: fixed
-  bug: 1661229
+  bugs:
+  - 1661229
   group: 3
 - note: 'More theme fixes and improvements'
   tag: fixed
-  bug: 1662536
-  bug2: 1662585
-  bug3: 1662831
-  bug4: 1659380
+  bugs:
+  - 1662536
+  - 1662585
+  - 1662831
+  - 1659380
   group: 3
 
 
 - note: 'Reply-To header moved in compose window; now appears under From header'
   tag: changed
-  bug: 1653814
+  bugs:
+  - 1653814
   group: 4
 - note: 'OpenPGP: Do not show external key UI when disabled by preference'
   tag: changed
-  bug: 1657111
+  bugs:
+  - 1657111
   group: 4
 - note: 'Calendar: Sidebar UI improvements'
   tag: changed
-  bug: 1621135
+  bugs:
+  - 1621135
   group: 4
 - note: 'Dragging & Dropping recipient pills resulted in lost pills when an error was present'
   tag: fixed
-  bug: 1663041
+  bugs:
+  - 1663041
   group: 4
 - note: 'Spellcheck suggestions were difficult to read in dark theme'
   tag: fixed
-  bug: 1663223
+  bugs:
+  - 1663223
   group: 4
 - note: 'Calendar: Multiple password prompts opened'
   tag: fixed
-  bug: 1664016
+  bugs:
+  - 1664016
   group: 4
 - note: 'Linux Distributions: UI was not rendered completely when built without updater'
   tag: fixed
-  bug: 1664607
-  bug2: 1664590
-  bug3: 1664721
+  bugs:
+  - 1664607
+  - 1664590
+  - 1664721
   group: 4
 
 # Unresolved
 - note: 'New news articles are not downloaded'
   tag: unresolved
-  bug: 1661955
+  bugs:
+  - 1661955

--- a/beta/82.0beta.yml
+++ b/beta/82.0beta.yml
@@ -11,7 +11,7 @@ release:
   import_system_requirements: '79.0beta'
 
   groups:
-  -
+  - 
   - "Changed and Fixed in Beta 2"
   - "Changed and Fixed in Beta 3"
 
@@ -19,112 +19,138 @@ notes:
 
 - note: 'MailExtensions: API for running content scripts on displayed messages'
   tag: new
-  bug: 15044475
+  bugs:
+  - 15044475
 - note: 'MailExtensions: browser.tabs.sendMessage API added'
   tag: new
-  bug: 1641576
+  bugs:
+  - 1641576
 
 - note: 'Chat icons updated'
   tag: changed
-  bug: 1662489
+  bugs:
+  - 1662489
 - note: 'MailExtensions: compose.begin functions now support creating a message with attachments'
   tag: changed
-  bug: 1662018
+  bugs:
+  - 1662018
 
 - note: 'Searching an address book list did not display results'
   tag: fixed
-  bug: 1663935
+  bugs:
+  - 1663935
 - note: 'New news articles were not downloaded'
   tag: fixed
-  bug: 1661955
+  bugs:
+  - 1661955
 - note: 'Drag and dropping recipient pills lost cursor and selection'
   tag: fixed
-  bug: 1663055
+  bugs:
+  - 1663055
 - note: 'Single-click deletion of recipient pills with middle mouse button restored'
   tag: fixed
-  bug: 1661438
+  bugs:
+  - 1661438
 - note: 'Creating a new calendar event did not require an event title'
   tag: fixed
-  bug: 1663303
+  bugs:
+  - 1663303
 - note: 'Windows installer was unreadable with Windows in high contrast mode'
   tag: fixed
-  bug: 1665321
+  bugs:
+  - 1665321
 
 - note: 'MailExtensions: Updating attachments with onBeforeSend.addListener() did not work'
   tag: fixed
-  bug: 1662015
+  bugs:
+  - 1662015
 
 # beta 2
 
-- note: 'Thunderbird will no longer automatically install updates when
-      Preferences tab is opened'
+- note: 'Thunderbird will no longer automatically install updates when Preferences tab
+    is opened'
   tag: changed
-  bug: 1666324
+  bugs:
+  - 1666324
   group: 2
 - note: 'OpenPGP: Improved support for encrypting with subkeys'
   tag: fixed
-  bug: 1665281
-  bug2: 1665497
+  bugs:
+  - 1665281
+  - 1665497
   group: 2
-- note: 'OpenPGP: Encrypted messages with international characters were
-    sometimes displayed incorrectly'
+- note: 'OpenPGP: Encrypted messages with international characters were sometimes displayed
+    incorrectly'
   tag: fixed
-  bug: 1665287
+  bugs:
+  - 1665287
   group: 2
 - note: 'Dark mode, high contrast, and Windows theming fixes'
   tag: fixed
-  bug: 1665336
-  bug2: 1667317
-  bug3: 1667109
+  bugs:
+  - 1665336
+  - 1667317
+  - 1667109
   group: 2
 
 # beta 3
 
 - note: 'Yahoo and AOL mail users using password authentication will be migrated to OAuth2'
   tag: changed
-  bug: 1606339
-  bug2: 1670892
+  bugs:
+  - 1606339
+  - 1670892
   group: 3
 
 - note: 'Thunderbird could freeze when updating global search index'
   tag: fixed
-  bug: 1669872
+  bugs:
+  - 1669872
   group: 3
-- note: 'Recipient address fields in compose window could expand to fill all available space'
+- note: 'Recipient address fields in compose window could expand to fill all available
+    space'
   tag: fixed
-  bug: 1666463
-  bug2: 1667173
-  bug3: 1667602
+  bugs:
+  - 1666463
+  - 1667173
+  - 1667602
   group: 3
 - note: 'OpenPGP Key Manager was missing from Tools menu on macOS'
   tag: fixed
-  bug: 1662279
+  bugs:
+  - 1662279
   group: 3
 - note: 'End-to-end encryption options not saved for multiple identities'
   tag: fixed
-  bug: 1667025
+  bugs:
+  - 1667025
   group: 3
 - note: 'Inserting emoji characters in message compose window caused unexpected behavior'
   tag: fixed
-  bug: 1665174
+  bugs:
+  - 1665174
   group: 3
 - note: 'HTTP refresh in content tabs did not work'
   tag: fixed
-  bug: 1667774
+  bugs:
+  - 1667774
   group: 3
 - note: 'Multiple issues with handling of self-signed SSL certificates addressed'
   tag: fixed
-  bug: 1590474
-  bug2: 1665577
-  bug3: 1667043
+  bugs:
+  - 1590474
+  - 1665577
+  - 1667043
   group: 3
 - note: 'Various keyboard navigation fixes'
   tag: fixed
-  bug: 1666885
-  bug2: 1667567
-  bug3: 1667614
+  bugs:
+  - 1666885
+  - 1667567
+  - 1667614
   group: 3
 - note: 'Various color-related theme fixes'
   tag: fixed
-  bug: 1668896
-  bug2: 1668410
+  bugs:
+  - 1668896
+  - 1668410

--- a/beta/83.0beta.yml
+++ b/beta/83.0beta.yml
@@ -11,126 +11,157 @@ release:
   import_system_requirements: '79.0beta'
 
   groups:
-  -
+  - 
   - "New, Changed, and Fixed in Beta 2"
   - "New, Changed, and Fixed in Beta 3"
 
 notes:
 - note: 'Calendar: Category colors now displayed in category selection dropdown'
   tag: new
-  bug: 736243
+  bugs:
+  - 736243
 - note: 'Calendar: "Edit" item added to event context menu'
   tag: new
-  bug: 1651783
+  bugs:
+  - 1651783
 - note: 'MailExtensions: "compose_attachments" context added to Menus API'
   tag: new
-  bug: 1670822
+  bugs:
+  - 1670822
 - note: 'MailExtensions: Menus API now available on displayed messages'
   tag: new
-  bug: 1670825
+  bugs:
+  - 1670825
 
 - note: 'MailExtensions: Changed contact properties now passed in contact.onUpdated event'
   tag: changed
-  bug: 1665454
+  bugs:
+  - 1665454
 
 - note: 'Searching global search results did not work'
   tag: fixed
-  bug: 1664761
+  bugs:
+  - 1664761
 - note: 'Link location was not focused by default when adding a hyperlink in message composer'
   tag: fixed
-  bug: 1670660
+  bugs:
+  - 1670660
 - note: 'Appmenu displayed visual glitches'
   tag: fixed
-  bug: 1636243
+  bugs:
+  - 1636243
 - note: 'Keyboard shortcut for toggling message "read" status not shown in menus'
   tag: fixed
-  bug: 1619248
+  bugs:
+  - 1619248
 - note: 'Chat: Previous conversations were not shown'
   tag: fixed
-  bug: 1665040
+  bugs:
+  - 1665040
 - note: 'Calendar: Subscribing to ICS calendars was not possible'
   tag: fixed
-  bug: 1663399
+  bugs:
+  - 1663399
 - note: 'Calendar: Reminder details appeared editable when viewing an event'
   tag: fixed
-  bug: 1651779
+  bugs:
+  - 1651779
 - note: 'Calendar: Two "Home" calendars were visible on a new profile'
   tag: fixed
-  bug: 1656782
+  bugs:
+  - 1656782
 
 
 # beta 2
-- note: 'Thunderbird prompts for an address to use when starting an email from an address book entry
-    with multiple addresses'
+- note: 'Thunderbird prompts for an address to use when starting an email from an address
+    book entry with multiple addresses'
   tag: new
-  bug: 84028
+  bugs:
+  - 84028
   group: 2
 
 - note: 'OpenPGP public key import now supports multi-file selection'
   tag: changed
-  bug: 1665145
+  bugs:
+  - 1665145
   group: 2
 
 - note: 'Advanced address book search dialog was unusable'
   tag: fixed
-  bug: 1668147
+  bugs:
+  - 1668147
   group: 2
 - note: 'Encrypted draft reply emails lost "Re:" prefix'
   tag: fixed
-  bug: 1661510
+  bugs:
+  - 1661510
   group: 2
 - note: 'Replying to a newsgroup message did not open the compose window'
   tag: fixed
-  bug: 1672667
+  bugs:
+  - 1672667
   group: 2
 - note: 'Unable to delete multiple newsgroup messages'
   tag: fixed
-  bug: 1657988
+  bugs:
+  - 1657988
   group: 2
-- note: 'Visual glitches when selecting multiple messages in the message pane and using Ctrl+click'
+- note: 'Visual glitches when selecting multiple messages in the message pane and using
+    Ctrl+click'
   tag: fixed
-  bug: 1671800
+  bugs:
+  - 1671800
   group: 2
 - note: 'Switching between dark and light mode could lead to unreadable text on macOS'
   tag: fixed
-  bug: 1668989
+  bugs:
+  - 1668989
   group: 2
 
 
 # beta 3
 - note: 'OpenPGP: Added option to disable attaching the public key to a signed message'
-  bug: 1654950
+  bugs:
+  - 1654950
   tag: new
   group: 3
 - note: 'OpenPGP: Added option to disable email subject encryption'
-  bug: 1666073
+  bugs:
+  - 1666073
   tag: new
   group: 3
 
-- note: 'MailExtensions: browser.tabs.create will now wait for "mail-delayed-startup-finished" event'
-  bug: 1674407
+- note: 'MailExtensions: browser.tabs.create will now wait for "mail-delayed-startup-finished"
+    event'
+  bugs:
+  - 1674407
   tag: changed
   group: 3
 
 - note: 'OpenPGP: Support for inline PGP messages improved'
-  bug: 1672851
+  bugs:
+  - 1672851
   tag: fixed
   group: 3
 - note: 'OpenPGP: Message security dialog showed unverified keys as unavailable'
-  bug: 1675285
+  bugs:
+  - 1675285
   tag: fixed
   group: 3
 - note: 'Calendar: HTML rendering in event descriptions restored'
-  bug: 1659363
-  bug2: 1673164
+  bugs:
+  - 1659363
+  - 1673164
   tag: fixed
   group: 3
 - note: 'Chat: New chat contact menu item did not function'
-  bug: 1663321
+  bugs:
+  - 1663321
   tag: fixed
   group: 3
 - note: 'Theming improvements'
-  bug: 1674606
-  bug2: 1673861
+  bugs:
+  - 1674606
+  - 1673861
   tag: fixed
   group: 3

--- a/beta/84.0beta.yml
+++ b/beta/84.0beta.yml
@@ -11,137 +11,175 @@ release:
   import_system_requirements: '79.0beta'
 
   groups:
-    -
-    - "Changed and Fixed in Beta 2"
-    - "New, Changed and Fixed in Beta 3"
+  - 
+  - "Changed and Fixed in Beta 2"
+  - "New, Changed and Fixed in Beta 3"
 
 notes:
 - note: 'OpenPGP: "Copy Key Id" option added to Key Manager context menu'
   tag: new
-  bug: 1675272
+  bugs:
+  - 1675272
 - note: 'Calendar: Support opening of .ics files by double-click'
   tag: new
-  bug: 357480
+  bugs:
+  - 357480
 
 - note: 'Thunderbird now only shows quota exceeded indications on the main window'
   tag: changed
-  bug: 1671748
+  bugs:
+  - 1671748
 - note: 'MailExtensions: message.compose API extended with EditAsNew and Template functions'
   tag: changed
-  bug: 1670379
+  bugs:
+  - 1670379
 - note: 'MailExtensions: menus API enabled in messages being composed'
   tag: changed
-  bug: 1670832
+  bugs:
+  - 1670832
 
-- note: '"Place replies in the folder of the message being replied to" did not work
-    when using "Reply to List"'
+- note: '"Place replies in the folder of the message being replied to" did not work when
+    using "Reply to List"'
   tag: fixed
-  bug: 522450
+  bugs:
+  - 522450
 - note: 'Thunderbird did not honor the "Run search on server" option when searching messages'
   tag: fixed
-  bug: 546925
-- note: 'OpenPGP: After importing a secret key, Key Manager displayed properties of the wrong key'
+  bugs:
+  - 546925
+- note: 'OpenPGP: After importing a secret key, Key Manager displayed properties of the
+    wrong key'
   tag: fixed
-  bug: 1667054
+  bugs:
+  - 1667054
 - note: 'OpenPGP: Key were missing from Key Manager'
   tag: fixed
-  bug: 1674521
+  bugs:
+  - 1674521
 - note: 'Print preview was blank'
   tag: fixed
-  bug: 1667557
+  bugs:
+  - 1667557
 - note: 'Autoconfig via LDAP did not work as expected'
   tag: fixed
-  bug: 1662433
+  bugs:
+  - 1662433
 - note: 'Various visual improvements'
   tag: fixed
-  bug: 1651476
-  bug2: 1666882
-  bug3: 1672909
-  bug4: 1674639
-  bug5: 1675000
-  bug6: 1676680
+  bugs:
+  - 1651476
+  - 1666882
+  - 1672909
+  - 1674639
+  - 1675000
+  - 1676680
 - note: 'MailExtensions: compose.beginForward did not respect composeDetails argument'
   tag: fixed
-  bug: 1658657
+  bugs:
+  - 1658657
 
 #beta 2
 - note: 'MailExtensions: getComposeDetails will wait for "compose-editor-ready" event'
   tag: changed
-  bug: 1675012
+  bugs:
+  - 1675012
   group: 2
 - note: 'MailExtensions: Honor allowScriptsToClose argument in windows.create API function'
   tag: changed
-  bug: 1675940
+  bugs:
+  - 1675940
   group: 2
 
 - note: "Highlight color for folders with unread messages wasn't visible in dark theme"
   tag: fixed
-  bug: 1676697
-  bug2: 1678029
+  bugs:
+  - 1676697
+  - 1678029
   group: 2
-- note: 'The "Link" button on the large attachments info bar failed to open up Filelink section in Options if the user had not yet configured Filelink'
+- note: 'The "Link" button on the large attachments info bar failed to open up Filelink
+    section in Options if the user had not yet configured Filelink'
   tag: fixed
-  bug: 1677647
+  bugs:
+  - 1677647
   group: 2
 - note: 'New mail icon was not removed from the system tray at shutdown'
   tag: fixed
-  bug: 1664586
+  bugs:
+  - 1664586
   group: 2
 - note: 'Address book: Printing members of a mailing list resulted in incorrect output'
   tag: fixed
-  bug: 1676859
+  bugs:
+  - 1676859
   group: 2
 - note: 'Calendar: Auto-detection failed for GSuite accounts'
   tag: fixed
-  bug: 1678302
+  bugs:
+  - 1678302
   group: 2
 - note: 'Calendar: Pressing Ctrl-Enter in the new event dialog would create duplicate events'
   tag: fixed
-  bug: 1668478
+  bugs:
+  - 1668478
   group: 2
 
 #beta 3
 - note: 'MailExtensions: Added browser.windows.openDefaultBrowser()'
   tag: new
-  bug: 1664708
+  bugs:
+  - 1664708
   group: 3
 
-- note: 'MailExtensions: APIs that returned an accountId will reflect the account the message belongs to, not what is stored in message headers'
+- note: 'MailExtensions: APIs that returned an accountId will reflect the account the message
+    belongs to, not what is stored in message headers'
   tag: changed
-  bug: 1644032
+  bugs:
+  - 1644032
   group: 3
-- note: 'MailExtensions: browserAction, composeAction, and messageDisplayAction toolbar buttons now support label and default_label properties'
+- note: 'MailExtensions: browserAction, composeAction, and messageDisplayAction toolbar
+    buttons now support label and default_label properties'
   tag: changed
-  bug: 1583478
+  bugs:
+  - 1583478
   group: 3
 
-- note: 'Running a quicksearch that returned no results did not offer to re-run as a global search'
+- note: 'Running a quicksearch that returned no results did not offer to re-run as a global
+    search'
   tag: fixed
-  bug: 1663153
+  bugs:
+  - 1663153
   group: 3
-- note: 'OpenPGP: When signature verification failed on an unencrypted message, Thunderbird incorrectly reported that the message was encrypted and could not be decrypted'
+- note: 'OpenPGP: When signature verification failed on an unencrypted message, Thunderbird
+    incorrectly reported that the message was encrypted and could not be decrypted'
   tag: fixed
-  bug: 1679768
+  bugs:
+  - 1679768
   group: 3
 - note: 'Address book: Some columns incorrectly displayed no data'
   tag: fixed
-  bug: 1631201
+  bugs:
+  - 1631201
   group: 3
-- note: 'Address book: The address book view did not update after changing the name format in the menu'
+- note: 'Address book: The address book view did not update after changing the name format
+    in the menu'
   tag: fixed
-  bug: 1678555
+  bugs:
+  - 1678555
   group: 3
 - note: 'Calendar: Dark theme was incomplete on Linux'
   tag: fixed
-  bug: 1655543
+  bugs:
+  - 1655543
   group: 3
 - note: 'Calendar: Could not import an ICS file into a CalDAV calendar'
   tag: fixed
-  bug: 1652984
+  bugs:
+  - 1652984
   group: 3
 
 # Known Issues
 - note: 'Printing from calendar does not work'
   tag: unresolved
-  bug: 1677819
+  bugs:
+  - 1677819
 

--- a/beta/85.0beta.yml
+++ b/beta/85.0beta.yml
@@ -11,142 +11,202 @@ release:
   import_system_requirements: '79.0beta'
 
   groups:
-    -
-    - "Fixed in Beta 2"
-    - "fixed in Beta 3"
+  - 
+  - "Fixed in Beta 2"
+  - "fixed in Beta 3"
 
 notes:
-- note: 'If a message fails to send, a message is now logged in the console tab of the Developer Toolbox which identifies which message failed to send'
+- note: 'If a message fails to send, a message is now logged in the console tab of the
+    Developer Toolbox which identifies which message failed to send'
   tag: new
-  bug: 1677980
+  bugs:
+  - 1677980
 - note: 'Address book: Added support for OAuth2 CardDAV providers'
   tag: new
-  bug: 1662979
-- note: 'Calendar: Thunderbird now informs the operating system that it knows how to open webcal: and webcals: URLs'
+  bugs:
+  - 1662979
+- note: 'Calendar: Thunderbird now informs the operating system that it knows how to open
+    webcal: and webcals: URLs'
   tag: new
-  bug: 352566
-- note: 'MailExtensions: Added the capability to query a specific headerMessageId via extension API which is persistent across application restarts'
+  bugs:
+  - 352566
+- note: 'MailExtensions: Added the capability to query a specific headerMessageId via extension
+    API which is persistent across application restarts'
   tag: new
-  bug: 1606573
+  bugs:
+  - 1606573
 - note: 'MailExtensions: new functions: accounts.getDefault() and accounts.getDefaultIdentity(accountId)'
   tag: new
-  bug: 1681141
+  bugs:
+  - 1681141
 
-- note: 'The UI Customization controls formerly in the Customize submenu have all been moved into the View menu'
+- note: 'The UI Customization controls formerly in the Customize submenu have all been
+    moved into the View menu'
   tag: changed
-  bug: 1668612
-- note: 'Address book: CardDAV is now enabled by default (it was previously behind a hidden preference and off by default)'
+  bugs:
+  - 1668612
+- note: 'Address book: CardDAV is now enabled by default (it was previously behind a hidden
+    preference and off by default)'
   tag: changed
-  bug: 1665230
+  bugs:
+  - 1665230
 - note: 'Calendar: Opening an event in the Today pane now opens the event summary'
   tag: changed
-  bug: 1673654
-- note: 'Calendar: When creating a new calendar, CalDAV is now used by default when supported by the server'
+  bugs:
+  - 1673654
+- note: 'Calendar: When creating a new calendar, CalDAV is now used by default when supported
+    by the server'
   tag: changed
-  bug: 1670420
-- note: 'MailExtensions: setComposeDetails and begin* functions of compose API now use body and plainTextBody as compose mode selectors'
+  bugs:
+  - 1670420
+- note: 'MailExtensions: setComposeDetails and begin* functions of compose API now use
+    body and plainTextBody as compose mode selectors'
   tag: changed
-  bug: 1681023
+  bugs:
+  - 1681023
 - note: 'MailExtensions: Variable names for accessing notifications have changed'
   tag: changed
-  bug: 1673958
+  bugs:
+  - 1673958
 - note: 'MailExtensions: Read-only address books now accessible'
   tag: changed
-  bug: 1679364
-- note: 'MailExtensions: messages.list(folder) on a non-existent folder now throws an ExtensionError exception'
+  bugs:
+  - 1679364
+- note: 'MailExtensions: messages.list(folder) on a non-existent folder now throws an ExtensionError
+    exception'
   tag: changed
-  bug: 15524497
+  bugs:
+  - 15524497
 
 - note: 'Various printing bugfixes'
   tag: fixed
-  bug: 1676166
-  bug2: 1677819
+  bugs:
+  - 1676166
+  - 1677819
 - note: 'Various message search toolbar fixes'
   tag: fixed
-  bug: 1679113
-  bug2: 1681010
+  bugs:
+  - 1679113
+  - 1681010
 - note: 'Address book: Read-only CardDAV address books were writable'
   tag: fixed
-  bug: 1680149
-- note: 'Address book: Autocomplete suggestions did not appear next to the field when editing address book entries with an IME enabled'
+  bugs:
+  - 1680149
+- note: 'Address book: Autocomplete suggestions did not appear next to the field when editing
+    address book entries with an IME enabled'
   tag: fixed
-  bug: 1676785
+  bugs:
+  - 1676785
 - note: 'Address book: Default address book preference was not honored'
   tag: fixed
-  bug: 1665430
+  bugs:
+  - 1665430
 - note: 'Compose window: The user-configured style for quoted text was not honored'
   tag: fixed
-  bug: 1641519
-- note: 'Compose window: Recipient addresses that had not yet been autocompleted were lost when clicking Send button'
+  bugs:
+  - 1641519
+- note: 'Compose window: Recipient addresses that had not yet been autocompleted were lost
+    when clicking Send button'
   tag: fixed
-  bug: 1674054
-  bug2: 1679848
-  bug3: 1681389
-- note: 'Compose window: New message is no longer marked as "changed" just from tabbing out of the recipient field without editing anything'
+  bugs:
+  - 1674054
+  - 1679848
+  - 1681389
+- note: 'Compose window: New message is no longer marked as "changed" just from tabbing
+    out of the recipient field without editing anything'
   tag: fixed
-  bug: 1681389
+  bugs:
+  - 1681389
 - note: 'Calendar: System timezone was not always properly detected'
   tag: fixed
-  bug: 1678839
-- note: 'Calendar: The toolbar in the invitation details dialog was not honoring the theme colors'
+  bugs:
+  - 1678839
+- note: 'Calendar: The toolbar in the invitation details dialog was not honoring the theme
+    colors'
   tag: fixed
-  bug: 1680755
-- note: 'Account settings: When creating a new account, some already entered settings did not copy to the Advanced Config dialog'
+  bugs:
+  - 1680755
+- note: 'Account settings: When creating a new account, some already entered settings did
+    not copy to the Advanced Config dialog'
   tag: fixed
-  bug: 1679664
-- note: 'Account settings: When updating the title of a news & blogging type account, the title of the tab did not change'
+  bugs:
+  - 1679664
+- note: 'Account settings: When updating the title of a news & blogging type account, the
+    title of the tab did not change'
   tag: fixed
-  bug: 1674645
+  bugs:
+  - 1674645
 - note: 'Chat: Could not add TLS certificate exceptions for XMPP connections'
   tag: fixed
-  bug: 1590471
-- note: 'MailExtensions: browserActions moved to a different toolbar are now properly displayed after restarting Thunderbird'
+  bugs:
+  - 1590471
+- note: 'MailExtensions: browserActions moved to a different toolbar are now properly displayed
+    after restarting Thunderbird'
   tag: fixed
-  bug: 1598190
-- note: 'MailExtensions: browser.compose.beginNew was not properly honoring plaintext vs HTML settings'
+  bugs:
+  - 1598190
+- note: 'MailExtensions: browser.compose.beginNew was not properly honoring plaintext vs
+    HTML settings'
   tag: fixed
-  bug: 1617377
-  bug2: 1658132
-- note: 'MailExtensions: browser.compose.setComposeDetails did not properly handling Windows-style line endings'
+  bugs:
+  - 1617377
+  - 1658132
+- note: 'MailExtensions: browser.compose.setComposeDetails did not properly handling Windows-style
+    line endings'
   tag: fixed
-  bug: 1672407
-- note: 'MailExtensions: windows.create and windows.update did not honor the titlePrefix parameter'
+  bugs:
+  - 1672407
+- note: 'MailExtensions: windows.create and windows.update did not honor the titlePrefix
+    parameter'
   tag: fixed
-  bug: 1647768
+  bugs:
+  - 1647768
 - note: 'MailExtensions: messages.getFull() did not return all parts with OpenPGP enabled'
   tag: fixed
-  bug: 1674964
+  bugs:
+  - 1674964
 
 # Beta 2
-- note: 'Sending messages and saving drafts with attachments that were copy & pasted into the compose window could fail'
+- note: 'Sending messages and saving drafts with attachments that were copy & pasted into
+    the compose window could fail'
   tag: fixed
-  bug: 1683548
+  bugs:
+  - 1683548
   group: 2
-- note: 'Calendar: Descriptions were sometimes blank when editing a single occurrence of a repeating event'
+- note: 'Calendar: Descriptions were sometimes blank when editing a single occurrence of
+    a repeating event'
   tag: fixed
-  bug: 1664731
+  bugs:
+  - 1664731
   group: 2
 - note: 'LDAP address book stability fix'
   tag: fixed
-  bug: 1680914
+  bugs:
+  - 1680914
   group: 2
 
 # Beta 3
-- note: 'Very long subject lines distorted the message compose and display windows, making them unusable'
+- note: 'Very long subject lines distorted the message compose and display windows, making
+    them unusable'
   tag: fixed
-  bug: 1682023
-  bug2: 77806
+  bugs:
+  - 1682023
+  - 77806
   group: 3
-- note: 'Messages with invalid vcard attachments were not marked as read when viewed in the preview window'
+- note: 'Messages with invalid vcard attachments were not marked as read when viewed in
+    the preview window'
   tag: fixed
-  bug: 1680468
+  bugs:
+  - 1680468
   group: 3
 - note: 'OpenPGP: Embedded newlines in an inline OpenPGP message failed to verify'
   tag: fixed
-  bug: 1679769
+  bugs:
+  - 1679769
   group: 3
 - note: 'Visual consistency and theme improvements'
   tag: fixed
-  bug: 1682808
-  bug2: 1682971
+  bugs:
+  - 1682808
+  - 1682971
   group: 3

--- a/beta/86.0beta.yml
+++ b/beta/86.0beta.yml
@@ -15,144 +15,179 @@ release:
   import_system_requirements: '79.0beta'
 
   groups:
-    -
-    - "Changed and Fixed in Beta 2"
-    - "Fixed in Beta 3"
+  - 
+  - "Changed and Fixed in Beta 2"
+  - "Fixed in Beta 3"
 
 notes:
-  - note: Allow pinning folder views to the Folder Pane
-    tag: new
-    bug: 1163555
-  - note: 'Message addressees that are not found in any address book will no longer appear in red type;
-     invalid addresses will appear red'
-    tag: changed
-    bug: 1660691
-  - note: 'Reenabled javascript-based message sending code by default'
-    tag: changed
-    bug: 1211292
-  - note: Folder pane color scheme overhauled with a focus on readability
-    tag: changed
-    bug: 1682065
-  - note: 'Calendar: Imported events are not sorted before being displayed'
-    tag: changed
-    bug: 1683060
-  - note: 'Thunderbird did not properly handle Self-signed certificates on IMAP servers'
-    tag: fixed
-    bug: 1676141
-  - note: 'Pressing command+enter to send a message on macOS did not work'
-    tag: fixed
-    bug: 1682147
-  - note: 'Saving an image from a message body with "Save Image As" did not work'
-    tag: fixed
-    bug: 1682873
-  - note: 'Various issues with IMAP folders with non-ASCII names, especially on Gmail'
-    tag: fixed
-    bug: 1685033
-    bug2: 1685450
-    bug3: 1686034
-    bug4: 1685449
-    bug5: 1686415
-    bug6: 1687452
-    bug7: 1687727
-    bug8: 1687938
-  - note: 'OpenPGP: Failed to save attachments that contained binary data after decryption'
-    tag: fixed
-    bug: 1686055
-  - note: 'Various global search fixes'
-    tag: fixed
-    bug: 1686317
-    bug2: 1578302
+- note: Allow pinning folder views to the Folder Pane
+  tag: new
+  bugs:
+  - 1163555
+- note: 'Message addressees that are not found in any address book will no longer appear
+    in red type; invalid addresses will appear red'
+  tag: changed
+  bugs:
+  - 1660691
+- note: 'Reenabled javascript-based message sending code by default'
+  tag: changed
+  bugs:
+  - 1211292
+- note: Folder pane color scheme overhauled with a focus on readability
+  tag: changed
+  bugs:
+  - 1682065
+- note: 'Calendar: Imported events are not sorted before being displayed'
+  tag: changed
+  bugs:
+  - 1683060
+- note: 'Thunderbird did not properly handle Self-signed certificates on IMAP servers'
+  tag: fixed
+  bugs:
+  - 1676141
+- note: 'Pressing command+enter to send a message on macOS did not work'
+  tag: fixed
+  bugs:
+  - 1682147
+- note: 'Saving an image from a message body with "Save Image As" did not work'
+  tag: fixed
+  bugs:
+  - 1682873
+- note: 'Various issues with IMAP folders with non-ASCII names, especially on Gmail'
+  tag: fixed
+  bugs:
+  - 1685033
+  - 1685450
+  - 1686034
+  - 1685449
+  - 1686415
+  - 1687452
+  - 1687727
+  - 1687938
+- note: 'OpenPGP: Failed to save attachments that contained binary data after decryption'
+  tag: fixed
+  bugs:
+  - 1686055
+- note: 'Various global search fixes'
+  tag: fixed
+  bugs:
+  - 1686317
+  - 1578302
 
-  - note: 'Importing an address book from a CSV file always reported an error'
-    tag: fixed
-    bug: 1685048
-  - note: 'Windows uninstaller did not always remove all Thunderbird program files'
-    tag: fixed
-    bug: 1678823
-  - note: 'Calendar: HTML entities appeared in event and task descriptions'
-    tag: fixed
-    bug: 1663947
-  - note: 'Calendar: FileLink UI fixes for Caldav calendars'
-    tag: fixed
-    bug: 1669803
-  - note: 'Calendar: Various dialog updates'
-    tag: fixed
-    bug: 1685947
+- note: 'Importing an address book from a CSV file always reported an error'
+  tag: fixed
+  bugs:
+  - 1685048
+- note: 'Windows uninstaller did not always remove all Thunderbird program files'
+  tag: fixed
+  bugs:
+  - 1678823
+- note: 'Calendar: HTML entities appeared in event and task descriptions'
+  tag: fixed
+  bugs:
+  - 1663947
+- note: 'Calendar: FileLink UI fixes for Caldav calendars'
+  tag: fixed
+  bugs:
+  - 1669803
+- note: 'Calendar: Various dialog updates'
+  tag: fixed
+  bugs:
+  - 1685947
 
-  - note: MailExtension options pages did not always completely load
-    tag: fixed
-    bug: 1641577
+- note: MailExtension options pages did not always completely load
+  tag: fixed
+  bugs:
+  - 1641577
 
 # beta 2
-  - note: Thunderbird will no longer allow installation of addons that use the legacy API
-    tag: changed
-    bug: 1688904
-    group: 2
+- note: Thunderbird will no longer allow installation of addons that use the legacy API
+  tag: changed
+  bugs:
+  - 1688904
+  group: 2
 
-  - note: 'Security information for S/MIME messages was not displayed correctly prior to a draft being saved'
-    tag: fixed
-    bug: 1683701
-    group: 2
-  - note: Automatic account setup did not use the provider email and display name
-    tag: fixed
-    bug: 1689079
-    group: 2
-  - note: Favorite Folder view did not maintain UI state between Thunderbird restarts
-    tag: fixed
-    bug: 1656501
-    group: 2
-  - note: Compact folder view did not work
-    tag: fixed
-    bug: 1689553
-    group: 2
-  - note: Searching addons from "Manage Extensions" page was not working
-    tag: fixed
-    bug: 1688887
-    group: 2
-  - note: Printing address book and calendar were broken in 86 beta 1
-    tag: fixed
-    bug: 1689461
-    bug2: 1689042
-    group: 2
-  - note: Recurring tasks were always marked incomplete; unable to use filters
-    tag: fixed
-    bug: 1686466
-    group: 2
-  - note: Thunderbird "about:" pages were not able to open links to web pages
-    tag: fixed
-    bug: 1690176
-    group: 2
-  - note: Various UI widgets not working
-    tag: fixed
-    bug: 1690467
-    bug2: 1690514
-    bug3: 1690098
-    bug4: 1689509
-    group: 2
+- note: 'Security information for S/MIME messages was not displayed correctly prior to
+    a draft being saved'
+  tag: fixed
+  bugs:
+  - 1683701
+  group: 2
+- note: Automatic account setup did not use the provider email and display name
+  tag: fixed
+  bugs:
+  - 1689079
+  group: 2
+- note: Favorite Folder view did not maintain UI state between Thunderbird restarts
+  tag: fixed
+  bugs:
+  - 1656501
+  group: 2
+- note: Compact folder view did not work
+  tag: fixed
+  bugs:
+  - 1689553
+  group: 2
+- note: Searching addons from "Manage Extensions" page was not working
+  tag: fixed
+  bugs:
+  - 1688887
+  group: 2
+- note: Printing address book and calendar were broken in 86 beta 1
+  tag: fixed
+  bugs:
+  - 1689461
+  - 1689042
+  group: 2
+- note: Recurring tasks were always marked incomplete; unable to use filters
+  tag: fixed
+  bugs:
+  - 1686466
+  group: 2
+- note: Thunderbird "about:" pages were not able to open links to web pages
+  tag: fixed
+  bugs:
+  - 1690176
+  group: 2
+- note: Various UI widgets not working
+  tag: fixed
+  bugs:
+  - 1690467
+  - 1690514
+  - 1690098
+  - 1689509
+  group: 2
 
 
 # beta 3
-  - note: Mail filter and junk logs were empty
-    tag: fixed
-    bug: 1690042
-    group: 3
-  - note: Converting an email to a calendar event or task failed
-    tag: fixed
-    bug: 1690900
-    group: 3
-  - note: 'Calendar: Changing the week start day from the default did not persist across restarts'
-    tag: fixed
-    bug: 1689775
-    group: 3
-  - note: Extension manager was missing link to addon support web page
-    tag: fixed
-    bug: 1642219
-    group: 3
-  - note: Extension manager did not show if an addon used experiment APIs
-    tag: fixed
-    bug: 1689060
-    group: 3
-  - note: 'Devtools: Viewing extension sources displayed a blank page'
-    tag: fixed
-    bug: 1690826
-    group: 3
+- note: Mail filter and junk logs were empty
+  tag: fixed
+  bugs:
+  - 1690042
+  group: 3
+- note: Converting an email to a calendar event or task failed
+  tag: fixed
+  bugs:
+  - 1690900
+  group: 3
+- note: 'Calendar: Changing the week start day from the default did not persist across
+    restarts'
+  tag: fixed
+  bugs:
+  - 1689775
+  group: 3
+- note: Extension manager was missing link to addon support web page
+  tag: fixed
+  bugs:
+  - 1642219
+  group: 3
+- note: Extension manager did not show if an addon used experiment APIs
+  tag: fixed
+  bugs:
+  - 1689060
+  group: 3
+- note: 'Devtools: Viewing extension sources displayed a blank page'
+  tag: fixed
+  bugs:
+  - 1690826
+  group: 3

--- a/beta/87.0beta.yml
+++ b/beta/87.0beta.yml
@@ -1,0 +1,171 @@
+release:
+  release_date: 2021-02-26
+  text: |
+    **These notes apply to Thunderbird version 87 beta 1 released February 26, 2021.**
+
+    **System Requirements:** [Details](/en-US/thunderbird/87.0beta/system-requirements/)
+
+    - Windows: Windows 7 or later
+    - Mac: macOS 10.12 or later
+    - Linux: GTK+ 3.14 or higher
+
+    <div style="color:magenta; font-weight:bold">Thunderbird since version 86.0b1 is using a new implementation of the message sending
+    code that is easier to maintain and more flexible. As with any major change, bugs are bound to happen. The old
+    behavior can be restored by setting the pref "mailnews.send.jsmodule" to false.</div>
+  import_system_requirements: '79.0beta'
+
+notes:
+- note: 'Thunderbird now runs as a native app on M1 Macs'
+  tag: new
+  bug: 1678775
+- note: 'Thunderbird is now supported on ARM64-based Linux'
+  tag: new
+  bug: 1673277
+- note: '<code>mid:</code> URI scheme defined in RFC 2392 is now supported to open messages by message ID'
+  tag: new
+  bug: 264270
+- note: 'Message Compose Window: New user interface for adding attachments'
+  tag: new
+  bug: 1640760
+- note: 'Message Compose Window: Clicking on an already-selected pill in the recipient list will now let you edit the address'
+  tag: new
+  bug: 1602901
+- note: 'Add-ons Manager: A warning indicating an add-on is incompatible is now shown by add-ons that use the legacy extension API'
+  tag: new
+  bug: 1689090
+- note: 'Extension API: Allow keyboard shortcuts to be added to composeAction buttons in the message compose window'
+  tag: new
+  bug: 1681153
+- note: 'Extension API: GSSAPI, Kerberos, and NTLM authentication are now supported in SmtpClient.jsm'
+  tag: new
+  bug: 1679731
+  bug2: 1679732
+- note: 'Extension API: <code>proxy</code> is now supported in SmtpClient.jsm'
+  tag: new
+  bug: 1690977
+
+- note: 'Address Book: Non-functional code for Outlook Express and WAB import was removed'
+  tag: changed
+  bug: 1687132
+- note: 'Account Manager: Support for Movemail accounts was removed'
+  tag: changed
+  bug: 1625741
+- note: 'Extension API: chromeTab tab type removed - use contentTab instead, which provides the same functionality'
+  tag: changed
+  bug: 1691304
+- note: 'Extension API: The contentPage parameter to contentTab has been renamed to url'
+  tag: changed
+  bug: 1691304
+
+- note: 'Mail: Uploading a large message to an IMAP server would sometimes prematurely display a time-out error'
+  tag: fixed
+  bug: 1618455
+- note: 'Mail: Spaces following soft line breaks in messages using quoted-printable and format=flowed were incorrectly encoded; existing messages which were previously incorrectly encoded may now display with some words not separated by a space'
+  tag: fixed
+  bug: 1689804
+- note: 'Mail: View Source context menu did not work'
+  tag: fixed
+  bug: 1689985
+- note: 'Mail: When saving multiple attachments, the save directory/folder was not remembered between saves'
+  tag: fixed
+  bug: 1565007
+- note: 'Mail: Sending mail with attachments to BCC recipients was slow'
+  tag: fixed
+  bug: 1692484
+- note: 'Mail: Outgoing messages were wordwrapped incorrectly when mailnews.wraplength is set to 0'
+  tag: fixed
+  bug: 1690957
+- note: 'Mail Window: Buttons on QuickFilter toolbar were squished on Mac'
+  tag: fixed
+  bug: 1689041
+- note: 'Mail Window: Items in the Today Pane were squished together'
+  tag: fixed
+  bug: 1666050
+- note: 'Mail Window: Twisty arrow on message threads was not highlighted properly when message row was selected on Mac'
+  tag: fixed
+  bug: 1689772
+- note: 'Mail Window: On non-default Windows themes, unread folder label would overlap folder icon when new mail arrived'
+  tag: fixed
+  bug: 1690971
+- note: 'Message Compose Window: Editing the list of recipients would auto-collapse the height of the recipients widget, even if the user had manually resized it'
+  tag: fixed
+  bug: 1691466
+- note: 'Message Compose Window: On Mac, formatting toolbar buttons with dropdowns had no space between the icon and the dropdown marker'
+  tag: fixed
+  bug: 1692537
+- note: 'Message Compose Window: Changing the language of the spellchecker did not work while editing a message'
+  tag: fixed
+  bug: 1690101
+- note: 'Search: Some labels in global search were blank'
+  tag: fixed
+  bug: 1691285
+- note: 'Address Book: Synching a read-only Google address book via CardDAV would fail'
+  tag: fixed
+  bug: 1693665
+- note: 'Address Book: Preferences related to an address book were not removed when the address book was deleted'
+  tag: fixed
+  bug: 1693667
+- note: 'Address Book: <code>getetag</code> elements in CardDAV requests used the wrong namespace'
+  tag: fixed
+  bug: 1693669
+- note: 'Address Book: If an error ocurred while syncing a CardDAV address book, it would not try to sync again until you restarted'
+  tag: fixed
+  bug: 1693670
+- note: 'Address Book: Column header borders would disappear on every second navigation in directory pane in AB themes'
+  tag: fixed
+  bug: 1693501
+- note: 'Calendar: Disabling a calendar did not hide its events from the month or multiweek views'
+  tag: fixed
+  bug: 1691844
+- note: 'Calendar: Changing the cache mode of a CalDAV calendar connection would lose the username of the account'
+  tag: fixed
+  bug: 1589491
+- note: 'Calendar: Server-provided colors for Google calendars were not handled properly'
+  tag: fixed
+  bug: 1691837
+- note: 'Calendar: Add-on calendars were sometimes not visible after restarting'
+  tag: fixed
+  bug: 1679723
+- note: 'Tasks: The calendar preview for a recurring task did not use all available space in the dialog window'
+  tag: fixed
+  bug: 1679129
+- note: 'Tasks: It was not possible to delete a recurring task'
+  tag: fixed
+  bug: 1688708
+- note: 'Theme: Read only input fields appeared as if they were editable'
+  tag: fixed
+  bug: 1689247
+- note: 'Theme: Title bar on Mac was not styled correctly in the built-in light theme'
+  tag: fixed
+  bug: 1666133
+- note: 'Theme: Title bar on Windows had an unneeded 1 pixel gap above the tabs when the menu bar was hidden'
+  tag: fixed
+  bug: 1693081
+- note: 'Theme: With Windows default theme in AB mode the selected rows had the incorrect icon color'
+  tag: fixed
+  bug: 1693086
+- note: 'Account Manager: Newly-added identities were not listed until you closed and reopened the Account Manager'
+  tag: fixed
+  bug: 1670464
+- note: 'Opening a message from the command-line using "-mail <URL>" parameter would return a TypeError'
+  tag: fixed
+  bug: 1684756
+- note: 'Installer: Option `/RemoveDistributionDir=false` passed to setup.exe was ignored'
+  tag: fixed
+  bug: 1663391
+- note: 'OpenPGP: Various errors when importing keys'
+  tag: fixed
+  bug: 1690391
+  bug2: 1689980
+  bug3: 1690387
+- note: 'OpenPGP: Messages with a high compression ratio (over 10x) could not be decrypted'
+  tag: fixed
+  bug: 1686984
+- note: 'Extension API: alert() from the message compose window failed'
+  tag: fixed
+  bug: 1679713
+
+- note: '{relnote needswork} Networking: IMAP:C-C TB: Handling of GetOfflineFileStream return value is wrong.'
+  tag: fixed
+  bug: 1596036
+

--- a/beta/87.0beta.yml
+++ b/beta/87.0beta.yml
@@ -32,7 +32,7 @@ notes:
 - note: 'Copying a large message to an IMAP server would sometimes prematurely display a time-out error'
   tag: fixed
   bug: 1618455
-- note: 'Spaces following soft line breaks in messages using quoted-printable and format=flowed were incorrectly encoded'
+- note: 'Spaces following soft line breaks in messages using quoted-printable and format=flowed were incorrectly encoded; existing messages which were previously incorrectly encoded may now display with some words not separated by a space'
   tag: fixed
   bug: 1689804
 - note: 'Context menu did not open in the message source window'

--- a/beta/87.0beta.yml
+++ b/beta/87.0beta.yml
@@ -17,98 +17,136 @@ release:
 notes:
 - note: 'Native support for macOS devices built with Apple Silicon CPUs'
   tag: new
-  bug: 1678775
+  bugs:
+  - 1678775
 - note: 'New user interface for adding attachments'
   tag: new
-  bug: 1640760
+  bugs:
+  - 1640760
 
-- note: 'Clicking on an already-selected pill in the recipient list will now allow editing the address'
+- note: 'Clicking on an already-selected pill in the recipient list will now allow editing
+    the address'
   tag: changed
-  bug: 1602901
+  bugs:
+  - 1602901
 - note: 'Movemail support was removed'
   tag: changed
-  bug: 1625741
+  bugs:
+  - 1625741
 
-- note: 'Copying a large message to an IMAP server would sometimes prematurely display a time-out error'
+- note: 'Copying a large message to an IMAP server would sometimes prematurely display
+    a time-out error'
   tag: fixed
-  bug: 1618455
-- note: 'Spaces following soft line breaks in messages using quoted-printable and format=flowed were incorrectly encoded;
-    existing messages which were previously incorrectly encoded may now display with some words not separated by a space'
+  bugs:
+  - 1618455
+- note: 'Spaces following soft line breaks in messages using quoted-printable and format=flowed
+    were incorrectly encoded; existing messages which were previously incorrectly encoded
+    may now display with some words not separated by a space'
   tag: fixed
-  bug: 1689804
+  bugs:
+  - 1689804
 - note: 'Context menu did not open in the message source window'
   tag: fixed
-  bug: 1689985
+  bugs:
+  - 1689985
 - note: 'Directory for saving multiple attachments was not remembered between saves'
   tag: fixed
-  bug: 1565007
-- note: 'Newly-added identities were not listed in the account manager until it was closed and reopened'
+  bugs:
+  - 1565007
+- note: 'Newly-added identities were not listed in the account manager until it was closed
+    and reopened'
   tag: fixed
-  bug: 1670464
-- note: 'Message headers in compose window disregarded manual resizing when adding additional recipients'
+  bugs:
+  - 1670464
+- note: 'Message headers in compose window disregarded manual resizing when adding additional
+    recipients'
   tag: fixed
-  bug: 1691466
-- note: 'Changing the language of the spellchecker did not work in while compose window was open'
+  bugs:
+  - 1691466
+- note: 'Changing the language of the spellchecker did not work in while compose window
+    was open'
   tag: fixed
-  bug: 1690101
+  bugs:
+  - 1690101
 - note: 'Opening a message from the command-line using "-mail &lt;URL&gt;" failed'
   tag: fixed
-  bug: 1684756
+  bugs:
+  - 1684756
 - note: 'OpenPGP: Various errors when importing keys'
   tag: fixed
-  bug: 1690391
-  bug2: 1689980
-  bug3: 1690387
+  bugs:
+  - 1690391
+  - 1689980
+  - 1690387
 - note: 'OpenPGP: Messages with a high compression ratio (over 10x) could not be decrypted'
   tag: fixed
-  bug: 1686984
+  bugs:
+  - 1686984
 - note: 'Some labels in global search results were blank'
   tag: fixed
-  bug: 1691285
+  bugs:
+  - 1691285
 - note: 'Address Book: Syncing a read-only Google address book via CardDAV failed'
   tag: fixed
-  bug: 1693665
-- note: 'Address Book: Preferences related to an address book were not removed when the address book was deleted'
+  bugs:
+  - 1693665
+- note: 'Address Book: Preferences related to an address book were not removed when the
+    address book was deleted'
   tag: fixed
-  bug: 1693667
+  bugs:
+  - 1693667
 - note: 'Address Book: CardDAV sync errors did not retry until Thunderbird was restarted'
   tag: fixed
-  bug: 1693670
+  bugs:
+  - 1693670
 - note: 'Calendar: Events from a disabled calendar were still visible'
   tag: fixed
-  bug: 1691844
-- note: 'Calendar: Changing the cache mode of a CalDAV calendar connection would lose the username of the account'
+  bugs:
+  - 1691844
+- note: 'Calendar: Changing the cache mode of a CalDAV calendar connection would lose the
+    username of the account'
   tag: fixed
-  bug: 1589491
+  bugs:
+  - 1589491
 - note: 'Calendar: Add-on calendars were sometimes not visible after restarting'
   tag: fixed
-  bug: 1679723
-- note: 'Calendar: The preview for a recurring task did not use all available space in the dialog window'
+  bugs:
+  - 1679723
+- note: 'Calendar: The preview for a recurring task did not use all available space in
+    the dialog window'
   tag: fixed
-  bug: 1679129
+  bugs:
+  - 1679129
 - note: 'Calendar: Removing a recurring task was not possible'
   tag: fixed
-  bug: 1688708
+  bugs:
+  - 1688708
 - note: 'Installer: Option to keep distribution directory on upgrade did not work'
   tag: fixed
-  bug: 1663391
+  bugs:
+  - 1663391
 - note: 'Various UI fixes for macOS: Quick Filter toolbar, Today Pane, message threads'
   tag: fixed
-  bug: 1689041
-  bug2: 1666050
-  bug3: 1689772
-  bug4: 1692537
+  bugs:
+  - 1689041
+  - 1666050
+  - 1689772
+  - 1692537
 - note: 'Various theme improvements'
   tag: fixed
-  bug: 1689247
-  bug2: 1666133
-  bug3: 1693081
-  bug4: 1693086
+  bugs:
+  - 1689247
+  - 1666133
+  - 1693081
+  - 1693086
 
 - note: 'MailExtensions: Calling alert() and related functions from a composeScript failed'
   tag: fixed
-  bug: 1679713
-- note: 'MailExtensions: Allow keyboard shortcuts to be added to composeAction buttons in the message compose window'
+  bugs:
+  - 1679713
+- note: 'MailExtensions: Allow keyboard shortcuts to be added to composeAction buttons
+    in the message compose window'
   tag: fixed
-  bug: 1681153
+  bugs:
+  - 1681153
 

--- a/beta/87.0beta.yml
+++ b/beta/87.0beta.yml
@@ -53,7 +53,7 @@ notes:
 - note: 'Changing the language of the spellchecker did not work in while compose window was open'
   tag: fixed
   bug: 1690101
-- note: 'Opening a message from the command-line using "-mail <URL>" failed'
+- note: 'Opening a message from the command-line using "-mail &lt;URL&gt;" failed'
   tag: fixed
   bug: 1684756
 - note: 'OpenPGP: Various errors when importing keys'

--- a/beta/87.0beta.yml
+++ b/beta/87.0beta.yml
@@ -15,144 +15,47 @@ release:
   import_system_requirements: '79.0beta'
 
 notes:
-- note: 'Thunderbird now runs as a native app on M1 Macs'
+- note: 'Native support for macOS devices built with Apple Silicon CPUs'
   tag: new
   bug: 1678775
-- note: 'Thunderbird is now supported on ARM64-based Linux'
-  tag: new
-  bug: 1673277
-- note: '<code>mid:</code> URI scheme defined in RFC 2392 is now supported to open messages by message ID'
-  tag: new
-  bug: 264270
-- note: 'Message Compose Window: New user interface for adding attachments'
+- note: 'New user interface for adding attachments'
   tag: new
   bug: 1640760
-- note: 'Message Compose Window: Clicking on an already-selected pill in the recipient list will now let you edit the address'
-  tag: new
-  bug: 1602901
-- note: 'Add-ons Manager: A warning indicating an add-on is incompatible is now shown by add-ons that use the legacy extension API'
-  tag: new
-  bug: 1689090
-- note: 'Extension API: Allow keyboard shortcuts to be added to composeAction buttons in the message compose window'
-  tag: new
-  bug: 1681153
-- note: 'Extension API: GSSAPI, Kerberos, and NTLM authentication are now supported in SmtpClient.jsm'
-  tag: new
-  bug: 1679731
-  bug2: 1679732
-- note: 'Extension API: <code>proxy</code> is now supported in SmtpClient.jsm'
-  tag: new
-  bug: 1690977
 
-- note: 'Address Book: Non-functional code for Outlook Express and WAB import was removed'
+- note: 'Address book support for Outlook Express and Windows Address Book was removed'
   tag: changed
   bug: 1687132
-- note: 'Account Manager: Support for Movemail accounts was removed'
+- note: 'Movemail support was removed'
   tag: changed
   bug: 1625741
-- note: 'Extension API: chromeTab tab type removed - use contentTab instead, which provides the same functionality'
-  tag: changed
-  bug: 1691304
-- note: 'Extension API: The contentPage parameter to contentTab has been renamed to url'
-  tag: changed
-  bug: 1691304
 
-- note: 'Mail: Uploading a large message to an IMAP server would sometimes prematurely display a time-out error'
+- note: 'Copying a large message to an IMAP server would sometimes prematurely display a time-out error'
   tag: fixed
   bug: 1618455
-- note: 'Mail: Spaces following soft line breaks in messages using quoted-printable and format=flowed were incorrectly encoded; existing messages which were previously incorrectly encoded may now display with some words not separated by a space'
+- note: 'Spaces following soft line breaks in messages using quoted-printable and format=flowed were incorrectly encoded'
   tag: fixed
   bug: 1689804
-- note: 'Mail: View Source context menu did not work'
+- note: 'Context menu did not open in the message source window'
   tag: fixed
   bug: 1689985
-- note: 'Mail: When saving multiple attachments, the save directory/folder was not remembered between saves'
+- note: 'Directory for saving multiple attachments was not remembered between saves'
   tag: fixed
   bug: 1565007
-- note: 'Mail: Sending mail with attachments to BCC recipients was slow'
-  tag: fixed
-  bug: 1692484
-- note: 'Mail: Outgoing messages were wordwrapped incorrectly when mailnews.wraplength is set to 0'
-  tag: fixed
-  bug: 1690957
-- note: 'Mail Window: Buttons on QuickFilter toolbar were squished on Mac'
-  tag: fixed
-  bug: 1689041
-- note: 'Mail Window: Items in the Today Pane were squished together'
-  tag: fixed
-  bug: 1666050
-- note: 'Mail Window: Twisty arrow on message threads was not highlighted properly when message row was selected on Mac'
-  tag: fixed
-  bug: 1689772
-- note: 'Mail Window: On non-default Windows themes, unread folder label would overlap folder icon when new mail arrived'
-  tag: fixed
-  bug: 1690971
-- note: 'Message Compose Window: Editing the list of recipients would auto-collapse the height of the recipients widget, even if the user had manually resized it'
-  tag: fixed
-  bug: 1691466
-- note: 'Message Compose Window: On Mac, formatting toolbar buttons with dropdowns had no space between the icon and the dropdown marker'
-  tag: fixed
-  bug: 1692537
-- note: 'Message Compose Window: Changing the language of the spellchecker did not work while editing a message'
-  tag: fixed
-  bug: 1690101
-- note: 'Search: Some labels in global search were blank'
-  tag: fixed
-  bug: 1691285
-- note: 'Address Book: Synching a read-only Google address book via CardDAV would fail'
-  tag: fixed
-  bug: 1693665
-- note: 'Address Book: Preferences related to an address book were not removed when the address book was deleted'
-  tag: fixed
-  bug: 1693667
-- note: 'Address Book: <code>getetag</code> elements in CardDAV requests used the wrong namespace'
-  tag: fixed
-  bug: 1693669
-- note: 'Address Book: If an error ocurred while syncing a CardDAV address book, it would not try to sync again until you restarted'
-  tag: fixed
-  bug: 1693670
-- note: 'Address Book: Column header borders would disappear on every second navigation in directory pane in AB themes'
-  tag: fixed
-  bug: 1693501
-- note: 'Calendar: Disabling a calendar did not hide its events from the month or multiweek views'
-  tag: fixed
-  bug: 1691844
-- note: 'Calendar: Changing the cache mode of a CalDAV calendar connection would lose the username of the account'
-  tag: fixed
-  bug: 1589491
-- note: 'Calendar: Server-provided colors for Google calendars were not handled properly'
-  tag: fixed
-  bug: 1691837
-- note: 'Calendar: Add-on calendars were sometimes not visible after restarting'
-  tag: fixed
-  bug: 1679723
-- note: 'Tasks: The calendar preview for a recurring task did not use all available space in the dialog window'
-  tag: fixed
-  bug: 1679129
-- note: 'Tasks: It was not possible to delete a recurring task'
-  tag: fixed
-  bug: 1688708
-- note: 'Theme: Read only input fields appeared as if they were editable'
-  tag: fixed
-  bug: 1689247
-- note: 'Theme: Title bar on Mac was not styled correctly in the built-in light theme'
-  tag: fixed
-  bug: 1666133
-- note: 'Theme: Title bar on Windows had an unneeded 1 pixel gap above the tabs when the menu bar was hidden'
-  tag: fixed
-  bug: 1693081
-- note: 'Theme: With Windows default theme in AB mode the selected rows had the incorrect icon color'
-  tag: fixed
-  bug: 1693086
-- note: 'Account Manager: Newly-added identities were not listed until you closed and reopened the Account Manager'
+- note: 'Newly-added identities were not listed in the account manager until it was closed and reopened'
   tag: fixed
   bug: 1670464
-- note: 'Opening a message from the command-line using "-mail <URL>" parameter would return a TypeError'
+- note: 'Clicking on an already-selected pill in the recipient list will now let you edit the address'
+  tag: fixed
+  bug: 1602901
+- note: 'Message headers in compose window disregarded manual resizing when adding additional recipients'
+  tag: fixed
+  bug: 1691466
+- note: 'Changing the language of the spellchecker did not work in while compose window was open'
+  tag: fixed
+  bug: 1690101
+- note: 'Opening a message from the command-line using "-mail <URL>" failed'
   tag: fixed
   bug: 1684756
-- note: 'Installer: Option `/RemoveDistributionDir=false` passed to setup.exe was ignored'
-  tag: fixed
-  bug: 1663391
 - note: 'OpenPGP: Various errors when importing keys'
   tag: fixed
   bug: 1690391
@@ -161,11 +64,53 @@ notes:
 - note: 'OpenPGP: Messages with a high compression ratio (over 10x) could not be decrypted'
   tag: fixed
   bug: 1686984
-- note: 'Extension API: alert() from the message compose window failed'
+- note: 'Some labels in global search results were blank'
+  tag: fixed
+  bug: 1691285
+- note: 'Address Book: Syncing a read-only Google address book via CardDAV failed'
+  tag: fixed
+  bug: 1693665
+- note: 'Address Book: Preferences related to an address book were not removed when the address book was deleted'
+  tag: fixed
+  bug: 1693667
+- note: 'Address Book: CardDAV sync errors did not retry until Thunderbird was restarted'
+  tag: fixed
+  bug: 1693670
+- note: 'Calendar: Events from a disabled calendar were still visible'
+  tag: fixed
+  bug: 1691844
+- note: 'Calendar: Changing the cache mode of a CalDAV calendar connection would lose the username of the account'
+  tag: fixed
+  bug: 1589491
+- note: 'Calendar: Add-on calendars were sometimes not visible after restarting'
+  tag: fixed
+  bug: 1679723
+- note: 'Calendar: The preview for a recurring task did not use all available space in the dialog window'
+  tag: fixed
+  bug: 1679129
+- note: 'Calendar: Removing a recurring task was not possible'
+  tag: fixed
+  bug: 1688708
+- note: 'Installer: Option to keep distribution directory on upgrade did not work'
+  tag: fixed
+  bug: 1663391
+- note: 'Various UI fixes for macOS: Quick Filter toolbar, Today Pane, message threads'
+  tag: fixed
+  bug: 1689041
+  bug2: 1666050
+  bug3: 1689772
+  bug4: 1692537
+- note: 'Various theme improvements'
+  tag: fixed
+  bug: 1689247
+  bug2: 1666133
+  bug3: 1693081
+  bug4: 1693086
+
+- note: 'MailExtensions: Calling alert() and related functions from a composeScript failed'
   tag: fixed
   bug: 1679713
-
-- note: '{relnote needswork} Networking: IMAP:C-C TB: Handling of GetOfflineFileStream return value is wrong.'
+- note: 'MailExtensions: Allow keyboard shortcuts to be added to composeAction buttons in the message compose window'
   tag: fixed
-  bug: 1596036
+  bug: 1681153
 

--- a/beta/87.0beta.yml
+++ b/beta/87.0beta.yml
@@ -22,9 +22,9 @@ notes:
   tag: new
   bug: 1640760
 
-- note: 'Address book support for Outlook Express and Windows Address Book was removed'
+- note: 'Clicking on an already-selected pill in the recipient list will now allow editing the address'
   tag: changed
-  bug: 1687132
+  bug: 1602901
 - note: 'Movemail support was removed'
   tag: changed
   bug: 1625741
@@ -32,7 +32,8 @@ notes:
 - note: 'Copying a large message to an IMAP server would sometimes prematurely display a time-out error'
   tag: fixed
   bug: 1618455
-- note: 'Spaces following soft line breaks in messages using quoted-printable and format=flowed were incorrectly encoded; existing messages which were previously incorrectly encoded may now display with some words not separated by a space'
+- note: 'Spaces following soft line breaks in messages using quoted-printable and format=flowed were incorrectly encoded;
+    existing messages which were previously incorrectly encoded may now display with some words not separated by a space'
   tag: fixed
   bug: 1689804
 - note: 'Context menu did not open in the message source window'
@@ -44,9 +45,6 @@ notes:
 - note: 'Newly-added identities were not listed in the account manager until it was closed and reopened'
   tag: fixed
   bug: 1670464
-- note: 'Clicking on an already-selected pill in the recipient list will now let you edit the address'
-  tag: fixed
-  bug: 1602901
 - note: 'Message headers in compose window disregarded manual resizing when adding additional recipients'
   tag: fixed
   bug: 1691466

--- a/loader.py
+++ b/loader.py
@@ -9,6 +9,7 @@ notes_dirs = [
 
 BUG_MKDOWN_T = "[{}](https://bugzilla.mozilla.org/show_bug.cgi?id={})"
 
+
 def mk_bug_links(bugs_list):
     """Used for the release notes preview to create a string of links to
     the relevant bugs in Bugzilla."""
@@ -18,6 +19,7 @@ def mk_bug_links(bugs_list):
         md = BUG_MKDOWN_T.format(bug_no, bug_no)
         links_list.append(md)
     return ' '.join(links_list)
+
 
 class ReleaseNotes(object):
     def __init__(self):
@@ -49,11 +51,8 @@ class ReleaseNotes(object):
                     n["release"]["system_requirements"] = ""
             # Push unresolved tags to separate "Known Issues" list.
             for note in n["notes"]:
-                bugs_list = []
-                for b in ('bug', 'bug2', 'bug3', 'bug4', 'bug5', 'bug6', 'bug7', 'bug8', 'bug9'):
-                    if b in note:
-                        bugs_list.append(int(note[b]))
-                note["bug_links"] = mk_bug_links(bugs_list)
+                if "bugs" in note:
+                    note["bug_links"] = mk_bug_links(note["bugs"])
                 if note["tag"] == "unresolved":
                     n["known_issues"].append(note)
                 else:

--- a/release/52.3.0.yml
+++ b/release/52.3.0.yml
@@ -13,43 +13,52 @@ release:
   import_system_requirements: "52.0"
 
 notes:
-  - bug: 1367156
-    tag: fixed
-    note: |
-      Unwanted inline images shown in rogue SPAM messages
-  - bug: 1293770
-    tag: fixed
-    note: |
-      Deleting message from the POP3 server not working when maildir storage was used
-  - bug: 1379912
-    tag: fixed
-    note: |
-      Message disposition flag (replied / forwarded) lost when reply or forwarded message was stored as draft and draft was sent later
-  - bug: 549106
-    tag: fixed
-    note: |
-      Inline images not scaled to fit when printing
-  - bug: 507541
-    tag: fixed
-    note: |
-      Selected text from another message sometimes included in a reply
-  - bug: 1367191
-    tag: fixed
-    note: |
-      No authorisation prompt displayed when inserting image into email body although image URL requires authentication
-  - bug: 1386585
-    tag: fixed
-    note: |
-      Large attachments taking a long time to open under some circumstances
-  - bug: 1356902
-    tag: unresolved
-    note: |
-      On Windows, "Send to > Mail recipient" does not work. Workaround: Install the [Microsoft Visual Studio 2015 redistributable runtime library][1] or the [Universal C Runtime for Windows Server][2].
-      
-      
-        [1]: https://www.microsoft.com/en-us/download/details.aspx?id=53587
-        [2]: https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows
-  - bug: 1176399
-    tag: unresolved
-    note: |
-      Multiple requests for master password when GMail OAuth2 is enabled
+- bugs:
+  - 1367156
+  tag: fixed
+  note: |
+    Unwanted inline images shown in rogue SPAM messages
+- bugs:
+  - 1293770
+  tag: fixed
+  note: |
+    Deleting message from the POP3 server not working when maildir storage was used
+- bugs:
+  - 1379912
+  tag: fixed
+  note: |
+    Message disposition flag (replied / forwarded) lost when reply or forwarded message was stored as draft and draft was sent later
+- bugs:
+  - 549106
+  tag: fixed
+  note: |
+    Inline images not scaled to fit when printing
+- bugs:
+  - 507541
+  tag: fixed
+  note: |
+    Selected text from another message sometimes included in a reply
+- bugs:
+  - 1367191
+  tag: fixed
+  note: |
+    No authorisation prompt displayed when inserting image into email body although image URL requires authentication
+- bugs:
+  - 1386585
+  tag: fixed
+  note: |
+    Large attachments taking a long time to open under some circumstances
+- bugs:
+  - 1356902
+  tag: unresolved
+  note: |
+    On Windows, "Send to > Mail recipient" does not work. Workaround: Install the [Microsoft Visual Studio 2015 redistributable runtime library][1] or the [Universal C Runtime for Windows Server][2].
+
+
+      [1]: https://www.microsoft.com/en-us/download/details.aspx?id=53587
+      [2]: https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows
+- bugs:
+  - 1176399
+  tag: unresolved
+  note: |
+    Multiple requests for master password when GMail OAuth2 is enabled

--- a/release/52.5.0.yml
+++ b/release/52.5.0.yml
@@ -12,22 +12,26 @@ release:
   import_system_requirements: '52.0'
 notes:
 - note: 'Better support for Charter/Spectrum IMAP: Thunderbird will now detect Charter''s
-    IMAP service and send an additional IMAP select command to the server. Check the
-    various preferences ending in "force_select" to see whether auto-detection has
-    discovered this case.'
-  bug: 1231592
+    IMAP service and send an additional IMAP select command to the server. Check the various
+    preferences ending in "force_select" to see whether auto-detection has discovered this
+    case.'
+  bugs:
+  - 1231592
   tag: new
 - note: In search folders spanning multiple base folders clicking on a message sometimes
     marked another message as read
-  bug: 1387581
+  bugs:
+  - 1387581
   tag: fixed
-- note: IMAP alerts have been corrected and now show the correct server name in case
-    of connection problems
-  bug: 1401026
+- note: IMAP alerts have been corrected and now show the correct server name in case of
+    connection problems
+  bugs:
+  - 1401026
   tag: fixed
-- note: POP alerts have been corrected and now indicate connection problems in case
-    the configured POP server cannot be found
-  bug: 1400359
+- note: POP alerts have been corrected and now indicate connection problems in case the
+    configured POP server cannot be found
+  bugs:
+  - 1400359
   tag: fixed
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird52.5">security
     fixes</a>

--- a/release/52.6.0.yml
+++ b/release/52.6.0.yml
@@ -11,18 +11,21 @@ release:
   bug_search_url: https://bugzilla.mozilla.org/buglist.cgi?o1=equals&v1=58%2B&f1=cf_tracking_thunderbird_esr52&query_format=advanced
   import_system_requirements: '52.0'
 notes:
-- note: 'Searching message bodies of messages in local folders, including filter and
-    quick filter operations, not working reliably: Content not found in base64-encode
-    message parts, non-ASCII text not found and false positives found.'
+- note: 'Searching message bodies of messages in local folders, including filter and quick
+    filter operations, not working reliably: Content not found in base64-encode message
+    parts, non-ASCII text not found and false positives found.'
   tag: fixed
-  bug: 1259534
-- note: Defective messages (without at least one expected header) not shown in IMAP
-    folders but shown on mobile devices
+  bugs:
+  - 1259534
+- note: Defective messages (without at least one expected header) not shown in IMAP folders
+    but shown on mobile devices
   tag: fixed
-  bug: 1345266
+  bugs:
+  - 1345266
 - note: 'Calendar: Unintended task deletion if numlock is enabled'
   tag: fixed
-  bug: 1409560
+  bugs:
+  - 1409560
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird52.6">security
     fixes</a>
   tag: fixed

--- a/release/52.7.0.yml
+++ b/release/52.7.0.yml
@@ -11,13 +11,15 @@ release:
   bug_search_url: https://bugzilla.mozilla.org/buglist.cgi?o1=equals&v1=59%2B&f1=cf_tracking_thunderbird_esr52&query_format=advanced
   import_system_requirements: '52.0'
 notes:
-- note: Searching message bodies of messages in local folders, including filter and
-    quick filter operations, did not find content in message attachments
+- note: Searching message bodies of messages in local folders, including filter and quick
+    filter operations, did not find content in message attachments
   tag: fixed
-  bug: 1434020
+  bugs:
+  - 1434020
 - note: Better error handling for Yahoo accounts
   tag: fixed
-  bug: 1408610
+  bugs:
+  - 1408610
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird52.7">security
     fixes</a>
   tag: fixed

--- a/release/52.9.0.yml
+++ b/release/52.9.0.yml
@@ -10,20 +10,24 @@ release:
     **Please refer to [Release Notes for version 52.0](https://thunderbird.net/en-US/thunderbird/52.0/releasenotes/) to see the list of improvements and fixed issues.**
   import_system_requirements: '52.0'
 notes:
-- note: 'Thunderbird will now prompt to compact IMAP folders even if the account is
-    online. Note: Under certain circumstances an incorrect estimate of the expected gain is shown.'
+- note: 'Thunderbird will now prompt to compact IMAP folders even if the account is online.
+    Note: Under certain circumstances an incorrect estimate of the expected gain is shown.'
   tag: changed
-- note: 'Complete fix of the EFAIL vulnerability: 1) Removing some HTML crafted to carry out an attack.
-    2) Optionally: Not decrypting subordinate message parts that otherwise might reveal decrypted content to the attacker.
-    Preference mailnews.p7m_subparts_external needs to be set to true for added security.'
+- note: 'Complete fix of the EFAIL vulnerability: 1) Removing some HTML crafted to carry
+    out an attack. 2) Optionally: Not decrypting subordinate message parts that otherwise
+    might reveal decrypted content to the attacker. Preference mailnews.p7m_subparts_external
+    needs to be set to true for added security.'
   tag: fixed
-  bug: 1419417
+  bugs:
+  - 1419417
 - note: 'Various problems when forwarding messages inline when using "simple" HTML view'
   tag: fixed
-  bug: 394322
+  bugs:
+  - 394322
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird52.9">security
     fixes</a>
   tag: fixed
 - note: Deleting or detaching attachments will corrupt messages under certain circumstances
   tag: unresolved
-  bug: 1473893
+  bugs:
+  - 1473893

--- a/release/52.9.1.yml
+++ b/release/52.9.1.yml
@@ -10,21 +10,25 @@ release:
     **Please refer to [Release Notes for version 52.0](https://thunderbird.net/en-US/thunderbird/52.0/releasenotes/) to see the list of improvements and fixed issues.**
   import_system_requirements: '52.0'
 notes:
-- note: 'Thunderbird will now prompt to compact IMAP folders even if the account is
-    online. Note: Under certain circumstances an incorrect estimate of the expected gain is shown.'
+- note: 'Thunderbird will now prompt to compact IMAP folders even if the account is online.
+    Note: Under certain circumstances an incorrect estimate of the expected gain is shown.'
   tag: changed
-- note: 'Complete fix of the EFAIL vulnerability: 1) Removing some HTML crafted to carry out an attack.
-    2) Optionally: Not decrypting subordinate message parts that otherwise might reveal decrypted content to the attacker.
-    Preference mailnews.p7m_subparts_external needs to be set to true for added security.'
+- note: 'Complete fix of the EFAIL vulnerability: 1) Removing some HTML crafted to carry
+    out an attack. 2) Optionally: Not decrypting subordinate message parts that otherwise
+    might reveal decrypted content to the attacker. Preference mailnews.p7m_subparts_external
+    needs to be set to true for added security.'
   tag: fixed
-  bug: 1419417
+  bugs:
+  - 1419417
 - note: 'Various problems when forwarding messages inline when using "simple" HTML view'
   tag: fixed
-  bug: 394322
+  bugs:
+  - 394322
 - note: Deleting or detaching attachments corrupted messages under certain circumstances
     (not working only in Thunderbird version 52.9.0)
   tag: fixed
-  bug: 1473893
+  bugs:
+  - 1473893
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird52.9">security
     fixes</a>
   tag: fixed

--- a/release/60.0.yml
+++ b/release/60.0.yml
@@ -21,236 +21,284 @@ notes:
 - note: When writing a message, a delete button now allows the removal of a recipient.
     This delete button is displayed when hovering the To/Cc/Bcc selector.
   tag: new
-  bug: 1100103
-- note: 'Many improvements to attachments handling during compose:
-    Attachments can now be reordered using a dialog, keyboard shortcuts, or drag and drop.
-    The "Attach" button moved to the right to be above the attachment pane.
-    The access key of the attachment pane (e.g. Alt+M, may vary depending on localization, Ctrl+M on Mac)
-    now also works to show or hide the pane.
-    The attachment pane can also be shown initially when
-    composing a new message. Right-click on the header to enable this option.
-    Hiding a non-empty attachment pane will now show a placeholder paperclip to indicate
-    the presence of attachments and avoid sending them accidentally.'
+  bugs:
+  - 1100103
+- note: 'Many improvements to attachments handling during compose: Attachments can now
+    be reordered using a dialog, keyboard shortcuts, or drag and drop. The "Attach" button
+    moved to the right to be above the attachment pane. The access key of the attachment
+    pane (e.g. Alt+M, may vary depending on localization, Ctrl+M on Mac) now also works
+    to show or hide the pane. The attachment pane can also be shown initially when composing
+    a new message. Right-click on the header to enable this option. Hiding a non-empty
+    attachment pane will now show a placeholder paperclip to indicate the presence of attachments
+    and avoid sending them accidentally.'
   tag: new
-  bug: 1428631
-  bug2: 663695
+  bugs:
+  - 1428631
+  - 663695
 - note: '"Edit Template" command. This also solves various problems when saving as template
     (duplicates created, message ID lost).'
   tag: new
-  bug: 1389062
+  bugs:
+  - 1389062
 - note: '"New Message from Template" command'
   tag: new
-  bug: 1389083
+  bugs:
+  - 1389083
 - note: Allow changing the Spellcheck Language from status bar
   tag: new
-  bug: 1399370
+  bugs:
+  - 1399370
 - note: Light and Dark themes
   tag: new
-  bug: 1456219
+  bugs:
+  - 1456219
 - note: WebExtension themes are now enabled in Thunderbird
   tag: new
-  bug: 1450670
+  bugs:
+  - 1450670
 - note: A default startup directory in the address book window can now be configured
   tag: new
-  bug: 1308776
+  bugs:
+  - 1308776
 - note: Individual feed update interval
   tag: new
-  bug: 1312813
-- note: An option under "Tools > Options, Advanced, General" now allows to select
-    whether date/time display will follow the application locale (adjusted by operating
-    system's format settings for that locale) or the locale selected in the operating
-    system's regional settings. In other words, an US English Thunderbird can use,
-    for example, German formats.
+  bugs:
+  - 1312813
+- note: An option under "Tools > Options, Advanced, General" now allows to select whether
+    date/time display will follow the application locale (adjusted by operating system's
+    format settings for that locale) or the locale selected in the operating system's regional
+    settings. In other words, an US English Thunderbird can use, for example, German formats.
   tag: new
-  bug: 1384007
+  bugs:
+  - 1384007
 - note: 'OAuth2 authentication for Yahoo and AOL'
   tag: new
-  bug: 1310384
+  bugs:
+  - 1310384
 - note: 'FIDO U2F support'
   tag: new
-  bug: 1444101
-- note: 'Thunderbird now allows the conversion of folders from mbox to maildir format
-    and vice versa. This is an **experimental** feature that needs to be enabled by
-    setting the preference mail.store_conversion_enabled.
-    Note that this functionality does not not work if the option
-    "Allow Windows Search/Spotlight to search messages" is selected.'
+  bugs:
+  - 1444101
+- note: 'Thunderbird now allows the conversion of folders from mbox to maildir format and
+    vice versa. This is an **experimental** feature that needs to be enabled by setting
+    the preference mail.store_conversion_enabled. Note that this functionality does not
+    not work if the option "Allow Windows Search/Spotlight to search messages" is selected.'
   tag: new
-  bug: 856087
-- note: 'Calendar: Allow copying, cutting or deleting of a selected occurrence or
-    the entire series for recurring events'
+  bugs:
+  - 856087
+- note: 'Calendar: Allow copying, cutting or deleting of a selected occurrence or the entire
+    series for recurring events'
   tag: new
-  bug: 393084
-- note: 'Calendar: Provide an option to display locations for events in calendar day
-    and week views'
+  bugs:
+  - 393084
+- note: 'Calendar: Provide an option to display locations for events in calendar day and
+    week views'
   tag: new
-  bug: 321434
-- note: 'Calendar: Provide the ability for sending/not sending meeting notifications
-    directly instead of showing a popup'
+  bugs:
+  - 321434
+- note: 'Calendar: Provide the ability for sending/not sending meeting notifications directly
+    instead of showing a popup'
   tag: new
-  bug: 463402
+  bugs:
+  - 463402
 - note: 'Calendar: Option to select the target calendar when pasting an event or task'
   tag: new
-  bug: 719351
-- note: 'Calendar: Allow email scheduling for CalDAV servers supporting server-side
-    scheduling'
+  bugs:
+  - 719351
+- note: 'Calendar: Allow email scheduling for CalDAV servers supporting server-side scheduling'
   tag: new
-  bug: 1299610
+  bugs:
+  - 1299610
 - note: Thunderbird Chat now contains multiple built-in message themes
   tag: new
-  bug: 1409839
-- note: "**IMPORTANT:** Add-ons not marked as compatible with Thunderbird
-    60 by their authors will be disabled (this can be reverted via preference extensions.strictCompatibility)"
+  bugs:
+  - 1409839
+- note: "**IMPORTANT:** Add-ons not marked as compatible with Thunderbird 60 by their authors\
+    \ will be disabled (this can be reverted via preference extensions.strictCompatibility)"
   tag: changed
-  bug: 1451097
+  bugs:
+  - 1451097
 - note: 'IMAP: When after sending a message storing that sent message fails, the message
     can now be stored in a local folder'
   tag: changed
-  bug: 28211
-- note: Add-on options can no longer be configured from the Add-on Manager page. A
-    new menu item "Add-on Options" is now available on the Tools menu.
+  bugs:
+  - 28211
+- note: Add-on options can no longer be configured from the Add-on Manager page. A new
+    menu item "Add-on Options" is now available on the Tools menu.
   tag: changed
-  bug: 1419145
-- note: When messages are composed in paragraph format, "body text" and split mail
-    quotes are converted to paragraphs when pressing the enter key
+  bugs:
+  - 1419145
+- note: When messages are composed in paragraph format, "body text" and split mail quotes
+    are converted to paragraphs when pressing the enter key
   tag: changed
-  bug: 1354002
-- note: '"Edit As New Message" will now use the account''s default compose format,
-    either HTML or plain text ignoring the format of the message. Plain text messages
-    will be converted to HTML and vice versa. Then using the modifier, the format
-    choice will be reverted.'
+  bugs:
+  - 1354002
+- note: '"Edit As New Message" will now use the account''s default compose format, either
+    HTML or plain text ignoring the format of the message. Plain text messages will be
+    converted to HTML and vice versa. Then using the modifier, the format choice will be
+    reverted.'
   tag: changed
-  bug: 731688
-- note: The "Edit Draft" command now also honors the use of the shift key to convert
-    HTML to plain text or vice versa when editing a draft
+  bugs:
+  - 731688
+- note: The "Edit Draft" command now also honors the use of the shift key to convert HTML
+    to plain text or vice versa when editing a draft
   tag: changed
-  bug: 1389771
-- note: The plain text to HTML conversion has been improved where such a conversion
-    is necessary for "Edit As New Message" or when the shift modifier is used for
-    "Edit Draft" or "New Message from Template".
+  bugs:
+  - 1389771
+- note: The plain text to HTML conversion has been improved where such a conversion is
+    necessary for "Edit As New Message" or when the shift modifier is used for "Edit Draft"
+    or "New Message from Template".
   tag: changed
-  bug: 1392052
-- note: During address entry, the matching part of the address is now shown in bold.
-    Preference mail.autoComplete.commentColumn allows to display the address book
-    where the address is stored.
+  bugs:
+  - 1392052
+- note: During address entry, the matching part of the address is now shown in bold. Preference
+    mail.autoComplete.commentColumn allows to display the address book where the address
+    is stored.
   tag: changed
-  bug: 1436290
-- note: When attaching a message via drag and drop, the subject of the message is
-    now used as attachment name instead of "Attached Message"
+  bugs:
+  - 1436290
+- note: When attaching a message via drag and drop, the subject of the message is now used
+    as attachment name instead of "Attached Message"
   tag: changed
-  bug: 209629
-- note: 'Better address book photo handling: Photos can be added by drag and drop and
-    a copy of all photos will be stored in the Thunderbird profile'
+  bugs:
+  - 209629
+- note: 'Better address book photo handling: Photos can be added by drag and drop and a
+    copy of all photos will be stored in the Thunderbird profile'
   tag: changed
-  bug: 892889
-- note: On first start, Thunderbird now shows the account setup dialog, no longer
-    the account provisioner dialog
+  bugs:
+  - 892889
+- note: On first start, Thunderbird now shows the account setup dialog, no longer the account
+    provisioner dialog
   tag: changed
-  bug: 1349259
-- note: Thunderbird follows Firefox' Photon design with rectangular tabs and many
-    other theme improvements
+  bugs:
+  - 1349259
+- note: Thunderbird follows Firefox' Photon design with rectangular tabs and many other
+    theme improvements
   tag: changed
-  bug: 1387877
-- note: 'When customizing the From: address, Thunderbird will now use this address
-    for the SMTP "MAIL FROM" command. Previously the address configured in the identity
-    was used. The preference mail.smtp.useSenderForSmtpMailFrom allows return to the
-    previous behavior.'
+  bugs:
+  - 1387877
+- note: 'When customizing the From: address, Thunderbird will now use this address for
+    the SMTP "MAIL FROM" command. Previously the address configured in the identity was
+    used. The preference mail.smtp.useSenderForSmtpMailFrom allows return to the previous
+    behavior.'
   tag: changed
-  bug: 1294027
+  bugs:
+  - 1294027
 - note: Native notifications on Linux are now re-enabled
   tag: changed
-  bug: 1358837
-- note: Thunderbird now uses Mozilla's latest proxy technology (add-on FoxyProxy now
-    supported)
+  bugs:
+  - 1358837
+- note: Thunderbird now uses Mozilla's latest proxy technology (add-on FoxyProxy now supported)
   tag: changed
-  bug: 791645
-- note: Thunderbird now uses the latest Rust-based Mozilla technology,
-    including Quantum's CSS engine (based on Servo) and encoding_rs, for displaying and encoding messages
+  bugs:
+  - 791645
+- note: Thunderbird now uses the latest Rust-based Mozilla technology, including Quantum's
+    CSS engine (based on Servo) and encoding_rs, for displaying and encoding messages
   tag: changed
-  bug: 1363281
+  bugs:
+  - 1363281
 - note: 'All certificates issued by Symantec roots before 2016-06-01 are distrusted for
-    use in TLS secured traffic in Thunderbird 60 and above. This applies to all
-    brands Symantec operated: Thawte, RapidSSL, GeoTrust, Verisign, and
-    Symantec. For usage in S/MIME the certificates remain valid.
-    Details [here](https://wiki.mozilla.org/CA/Additional_Trust_Changes#Symantec).'
+    use in TLS secured traffic in Thunderbird 60 and above. This applies to all brands
+    Symantec operated: Thawte, RapidSSL, GeoTrust, Verisign, and Symantec. For usage in
+    S/MIME the certificates remain valid. Details [here](https://wiki.mozilla.org/CA/Additional_Trust_Changes#Symantec).'
   tag: changed
-  bug: 1437826
+  bugs:
+  - 1437826
 - note: 'Calendar: Removal of capability to send email invitations compatible to Outlook
     2002 and earlier'
   tag: changed
-  bug: 463402
+  bugs:
+  - 463402
 - note: 'Calendar: Reminders on read-only calendars can now be dismissed, while reminders
-    for missed events will now only be displayed for writable calendars if option
-    "Show missed reminders for writable calendars" is selected'
+    for missed events will now only be displayed for writable calendars if option "Show
+    missed reminders for writable calendars" is selected'
   tag: changed
-  bug: 356002
+  bugs:
+  - 356002
 - note: 'Thunderbird Chat: Nicknames inside of messages are colored to match the participants
     list'
   tag: changed
-  bug: 1409901
-- note: 'When many Thunderbird clients or other email clients accessed the same IMAP
-    draft folder, messages were sometimes sent with the wrong identity. This has been
-    corrected and the user will be notified if none of their identities matches the
-    draft. '
+  bugs:
+  - 1409901
+- note: 'When many Thunderbird clients or other email clients accessed the same IMAP draft
+    folder, messages were sometimes sent with the wrong identity. This has been corrected
+    and the user will be notified if none of their identities matches the draft. '
   tag: fixed
-  bug: 394216
-- note: 'Various problems related to handling the IMAP trash folder: Under certain
-    circumstances the selection of the trash folder didn''t persist, for example when
-    the name contained non-ASCII characters, or in localized versions of Thunderbird.
-    At times unwanted additional trash folders were created. Selection of a trash
-    folder didn''t give immediate visual feedback.'
+  bugs:
+  - 394216
+- note: 'Various problems related to handling the IMAP trash folder: Under certain circumstances
+    the selection of the trash folder didn''t persist, for example when the name contained
+    non-ASCII characters, or in localized versions of Thunderbird. At times unwanted additional
+    trash folders were created. Selection of a trash folder didn''t give immediate visual
+    feedback.'
   tag: fixed
-  bug: 1335982
+  bugs:
+  - 1335982
 - note: Shared IMAP folders not shown in subscribe dialog under some circumstances
   tag: fixed
-  bug: 1419735
-- note: Messages moved between IMAP accounts were missing parts (embedded content
-    or attachments) under some circumstances
+  bugs:
+  - 1419735
+- note: Messages moved between IMAP accounts were missing parts (embedded content or attachments)
+    under some circumstances
   tag: fixed
-  bug: 1430480
+  bugs:
+  - 1430480
 - note: Improvements encoding/decoding message headers
   tag: fixed
-  bug: 1437282
+  bugs:
+  - 1437282
 - note: Text in the address book card view wasn't selectable
   tag: fixed
-  bug: 96968
-- note: "Passwords can now contain non-ASCII characters, like international characters,
-    for example áäß, and symbols, for example €§£. Note: According to RFC 5721, passwords are
-    encoded using UTF-8 which can lead to problems with non-compliant providers, for example
-    office365.com."
+  bugs:
+  - 96968
+- note: "Passwords can now contain non-ASCII characters, like international characters,\
+    \ for example áäß, and symbols, for example €§£. Note: According to RFC 5721, passwords\
+    \ are encoded using UTF-8 which can lead to problems with non-compliant providers,\
+    \ for example office365.com."
   tag: fixed
-  bug: 312593
-- note: 'Outlook import. Note: Mail, address book and settings need to be imported individually as
-    "Import Everything" currently does not work.'
+  bugs:
+  - 312593
+- note: 'Outlook import. Note: Mail, address book and settings need to be imported individually
+    as "Import Everything" currently does not work.'
   tag: fixed
-  bug: 1176748
-  bug2: 1474870
+  bugs:
+  - 1176748
+  - 1474870
 - note: 'Localized versions of Thunderbird didn''t show a localized name for Hotmail''s
     "Deleted" folder'
   tag: fixed
-  bug: 1320191
+  bugs:
+  - 1320191
 - note: 'Contacts sidebar: Selection and context menu behavior'
   tag: fixed
-  bug: 1322032
+  bugs:
+  - 1322032
 - note: 'Better error handling for Gmail authentication to avoid re-downloading of folders'
   tag: fixed
-  bug: 1453643
+  bugs:
+  - 1453643
 - note: Thunderbird used a stale cached password after user edited a saved password
   tag: fixed
-  bug: 516464
+  bugs:
+  - 516464
 - note: 'Calendar: Wrong time formatting for some time zones'
   tag: fixed
-  bug: 1396639
+  bugs:
+  - 1396639
 - note: "Calendar: Can't copy information from event dialog for received invitations"
   tag: fixed
-  bug: 390753
+  bugs:
+  - 390753
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60">security
     fixes</a>
   tag: fixed
-- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced Property Editor
-    or Link Properties dialog'
+- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced
+    Property Editor or Link Properties dialog'
   tag: unresolved
-  bug: 1501663
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+  bugs:
+  - 1501663
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912

--- a/release/60.2.1.yml
+++ b/release/60.2.1.yml
@@ -18,62 +18,80 @@ release:
 
   import_system_requirements: '60.0beta'
 notes:
-- note: 'Calendar: Default values for the first day of the week and working days
-    are now derived from the selected datetime formatting locale
-    (restart after changing locale in the OS required)'
+- note: 'Calendar: Default values for the first day of the week and working days are now
+    derived from the selected datetime formatting locale (restart after changing locale
+    in the OS required)'
   tag: changed
-  bug: 1481790
+  bugs:
+  - 1481790
 - note: 'Calendar: Switch to a Photon-style icon set for all platforms'
   tag: changed
-  bug: 1446748
+  bugs:
+  - 1446748
 - note: 'Multiple requests for master password when Google Mail or Calendar OAuth2 is enabled'
   tag: fixed
-  bug: 1176399
-  bug2: 682474
+  bugs:
+  - 1176399
+  - 682474
 - note: 'Scrollbar of the address entry auto-complete popup does not work'
   tag: fixed
-  bug: 1486178
+  bugs:
+  - 1486178
 - note: "Security info dialog in compose window does not show certificate status"
   tag: fixed
-  bug: 1293378
-- note: "Links in the Add-on Manager's search results and theme browsing tabs open in external browser"
+  bugs:
+  - 1293378
+- note: "Links in the Add-on Manager's search results and theme browsing tabs open in external\
+    \ browser"
   tag: fixed
-  bug: 1482342
-  bug2: 1481088
-- note: 'Localized versions of Thunderbird didn''t show a localized name for the "Drafts" and "Sent" folders
-    for certain IMAP providers (particularly in France)'
+  bugs:
+  - 1482342
+  - 1481088
+- note: 'Localized versions of Thunderbird didn''t show a localized name for the "Drafts"
+    and "Sent" folders for certain IMAP providers (particularly in France)'
   tag: fixed
-  bug: 543227
-- note: 'Replying to a message with an empty subject inserted Re: twice (not working in Thunderbird 60.0)'
+  bugs:
+  - 543227
+- note: 'Replying to a message with an empty subject inserted Re: twice (not working in
+    Thunderbird 60.0)'
   tag: fixed
-  bug: 1476788
-- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (not working in Thunderbird 60.0)'
+  bugs:
+  - 1476788
+- note: 'Spellcheck marks disappeared erroneously for words with an apostrophe (not working
+    in Thunderbird 60.0)'
   tag: fixed
-  bug: 1418629
+  bugs:
+  - 1418629
 - note: 'Calendar: First day of the week cannot be set'
   tag: fixed
-  bug: 1473294
+  bugs:
+  - 1473294
 - note: 'Calendar: Several fixes related to cutting/deleting of events and email scheduling'
   tag: fixed
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.2.1">security
     fixes</a>
   tag: fixed
-- note: 'Thunderbird will hang if HTML signature references non-existent image (solution forthcoming)'
+- note: 'Thunderbird will hang if HTML signature references non-existent image (solution
+    forthcoming)'
   tag: unresolved
-  bug: 1495698
-- note: 'According to RFC 5721, passwords containing non-ASCII characters are
-    encoded using UTF-8 which can lead to problems with non-compliant providers, for example
-    office365.com'
+  bugs:
+  - 1495698
+- note: 'According to RFC 5721, passwords containing non-ASCII characters are encoded using
+    UTF-8 which can lead to problems with non-compliant providers, for example office365.com'
   tag: unresolved
-  bug: 1500772
-- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced Property Editor
-    or Link Properties dialog'
+  bugs:
+  - 1500772
+- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced
+    Property Editor or Link Properties dialog'
   tag: unresolved
-  bug: 1501663
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+  bugs:
+  - 1501663
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912
 - note: 'Chat: Twitter not working due to API changes at Twitter.com (solution forthcoming)'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.3.0.yml
+++ b/release/60.3.0.yml
@@ -19,47 +19,59 @@ release:
 notes:
 - note: 'Various Theme fixes where incorrect colors, backgrounds, etc. were displayed'
   tag: fixed
-  bug: 1498908
+  bugs:
+  - 1498908
 - note: 'Add-on Options menu not working on Mac'
   tag: fixed
-  bug: 1482334
+  bugs:
+  - 1482334
 - note: 'Shift+PageUp/PageDown in Write window'
   tag: fixed
-  bug: 1482425
+  bugs:
+  - 1482425
 - note: 'Saving content of Write windows didn''t overwrite existing file'
   tag: fixed
-  bug: 1498483
+  bugs:
+  - 1498483
 - note: 'Issues related to "Edit Template" command'
   tag: fixed
-  bug: 1498866
+  bugs:
+  - 1498866
 - note: 'Gloda attachment filtering'
   tag: fixed
-  bug: 1499860
+  bugs:
+  - 1499860
 - note: 'Mailing list address auto-complete enter/return handling'
   tag: fixed
-  bug: 1499410
+  bugs:
+  - 1499410
 - note: 'Thunderbird hung if HTML signature references non-existent image'
   tag: fixed
-  bug: 1495698
+  bugs:
+  - 1495698
 - note: 'Filters not working for headers that appear more than once'
   tag: fixed
-  bug: 678322
+  bugs:
+  - 678322
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.3">security
     fixes</a>
   tag: fixed
-- note: 'According to RFC 5721, passwords containing non-ASCII characters are
-    encoded using UTF-8 which can lead to problems with non-compliant providers, for example
-    office365.com'
+- note: 'According to RFC 5721, passwords containing non-ASCII characters are encoded using
+    UTF-8 which can lead to problems with non-compliant providers, for example office365.com'
   tag: unresolved
-  bug: 1500772
-- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced Property Editor
-    or Link Properties dialog'
+  bugs:
+  - 1500772
+- note: 'Double-clicking on a word in the Write window sometimes launches the Advanced
+    Property Editor or Link Properties dialog'
   tag: unresolved
-  bug: 1501663
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+  bugs:
+  - 1501663
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912
 - note: 'Chat: Twitter not working due to API changes at Twitter.com (solution forthcoming)'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.3.1.yml
+++ b/release/60.3.1.yml
@@ -17,37 +17,46 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Double-clicking on a word in the Write window sometimes launched the Advanced Property Editor
-    or Link Properties dialog'
+- note: 'Double-clicking on a word in the Write window sometimes launched the Advanced
+    Property Editor or Link Properties dialog'
   tag: fixed
-  bug: 1501663
+  bugs:
+  - 1501663
 - note: 'Cookie removal (not working since Thunderbird version 52)'
   tag: fixed
-  bug: 1503654
+  bugs:
+  - 1503654
 - note: '"Download rest of message" not working if global inbox was used'
   tag: fixed
-  bug: 1503395
-- note: 'Encoding problems for users (especially in Poland) when a file was sent via a folder using
-    "Sent to > Mail recipient" due to a problem in the Thunderbird MAPI interface'
+  bugs:
+  - 1503395
+- note: 'Encoding problems for users (especially in Poland) when a file was sent via a
+    folder using "Sent to > Mail recipient" due to a problem in the Thunderbird MAPI interface'
   tag: fixed
-  bug: 1505315
-- note: 'According to RFC 4616 and RFC 5721, passwords containing non-ASCII characters are
-    encoded using UTF-8 which can lead to problems with non-compliant providers, for example
-    office365.com. The SMTP LOGIN and POP3 USER/PASS authentication methods are now using
-    a Latin-1 encoding again to work around this issue.'
+  bugs:
+  - 1505315
+- note: 'According to RFC 4616 and RFC 5721, passwords containing non-ASCII characters
+    are encoded using UTF-8 which can lead to problems with non-compliant providers, for
+    example office365.com. The SMTP LOGIN and POP3 USER/PASS authentication methods are
+    now using a Latin-1 encoding again to work around this issue.'
   tag: fixed
-  bug: 1500772
+  bugs:
+  - 1500772
 - note: 'Shutdown crash/hang after entering an empty IMAP password'
   tag: fixed
-  bug: 1257058
-- note: 'Under some circumstances Thunderbird on Mac will send attachments using the
-    so-called AppleDouble format which can lead to problems with mail servers and recipients'
+  bugs:
+  - 1257058
+- note: 'Under some circumstances Thunderbird on Mac will send attachments using the so-called
+    AppleDouble format which can lead to problems with mail servers and recipients'
   tag: unresolved
-  bug: 1506800
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+  bugs:
+  - 1506800
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912
 - note: 'Chat: Twitter not working due to API changes at Twitter.com (solution forthcoming)'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.3.2.yml
+++ b/release/60.3.2.yml
@@ -17,38 +17,50 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Under some circumstances Thunderbird on Mac will send attachments using the
-    so-called AppleDouble format which can lead to problems with mail servers and recipients'
+- note: 'Under some circumstances Thunderbird on Mac will send attachments using the so-called
+    AppleDouble format which can lead to problems with mail servers and recipients'
   tag: fixed
-  bug: 1506800
+  bugs:
+  - 1506800
 - note: 'Encoding problems when exporting address books or messages using the system charset.
     Messages are now always exported using the UTF-8 encoding.'
   tag: fixed
-  bug: 1506422
+  bugs:
+  - 1506422
 - note: 'If the "Date" header of a message was invalid, Jan 1970 or Dec 1969 was displayed.
     Now using date from "Received" header instead.'
   tag: fixed
-  bug: 32216
+  bugs:
+  - 32216
 - note: 'Body search/filtering didn''t reliably ignore content of tags'
   tag: fixed
-  bug: 1230815
-- note: 'Inappropriate warning "Thunderbird prevented the site (addons.thunderbird.net) 
+  bugs:
+  - 1230815
+- note: 'Inappropriate warning "Thunderbird prevented the site (addons.thunderbird.net)
     from asking you to install software on your computer" when installing add-ons'
   tag: fixed
-  bug: 1230815
-- note: 'Incorrect display of correspondents column since own email address was not always detected'
+  bugs:
+  - 1230815
+- note: 'Incorrect display of correspondents column since own email address was not always
+    detected'
   tag: fixed
-  bug: 1271353
+  bugs:
+  - 1271353
 - note: 'Spurious &amp;#xA; (encoded newline) inserted into drafts and sent email'
   tag: fixed
-  bug: 1509102
-- note: 'New email not inserted in correct sort order in threaded unified view or search folder'
+  bugs:
+  - 1509102
+- note: 'New email not inserted in correct sort order in threaded unified view or search
+    folder'
   tag: fixed
-  bug: 1470049
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+  bugs:
+  - 1470049
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.3.3.yml
+++ b/release/60.3.3.yml
@@ -17,32 +17,40 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Thunderbird 60 will migrate security databases (key3.db, cert8.db to key4.db, cert9.db).
-    Thunderbird 60.3.2 and earlier contained a fault that potentially deleted saved passwords
-    and private certificate keys for users using a master password.
-    Version 60.3.3 will prevent the loss of data; affected users
-    who have already upgraded to version 60.3.2 or earlier can restore the deleted key3.db
-    file from backup to complete the migration.'
+- note: 'Thunderbird 60 will migrate security databases (key3.db, cert8.db to key4.db,
+    cert9.db). Thunderbird 60.3.2 and earlier contained a fault that potentially deleted
+    saved passwords and private certificate keys for users using a master password. Version
+    60.3.3 will prevent the loss of data; affected users who have already upgraded to version
+    60.3.2 or earlier can restore the deleted key3.db file from backup to complete the
+    migration.'
   tag: mitigated
-  bug: 1510212
+  bugs:
+  - 1510212
 - note: 'Address book search and auto-complete slowness introduced in Thunderbird 60.3.2'
   tag: fixed
-  bug: 1511885
-- note: 'Plain text markup with * for bold, / for italics, _ for underline and | for code did not
-    work when the enclosed text contained non-ASCII characters'
+  bugs:
+  - 1511885
+- note: 'Plain text markup with * for bold, / for italics, _ for underline and | for code
+    did not work when the enclosed text contained non-ASCII characters'
   tag: fixed
-  bug: 1505911
-- note: 'While composing a message, a link not removed when link location was removed in the link properties panel'
+  bugs:
+  - 1505911
+- note: 'While composing a message, a link not removed when link location was removed in
+    the link properties panel'
   tag: fixed
-  bug: 1510183
-- note: 'Decoding problems for messages with less common charsets (cp932, cp936). This will be
-    fixed in version 60.4.0.'
+  bugs:
+  - 1510183
+- note: 'Decoding problems for messages with less common charsets (cp932, cp936). This
+    will be fixed in version 60.4.0.'
   tag: unresolved
-  bug: 1511950
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+  bugs:
+  - 1511950
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.4.0.yml
+++ b/release/60.4.0.yml
@@ -17,34 +17,42 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'WebExtensions FileLink API to facilitate FileLink add-ons.
-    For the future version Thunderbird 60.5.0:
-    WeTransfer will be included in Thunderbird 60.5.0 and the [Dropbox add-on](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/)
+- note: 'WebExtensions FileLink API to facilitate FileLink add-ons. For the future version
+    Thunderbird 60.5.0: WeTransfer will be included in Thunderbird 60.5.0 and the [Dropbox
+    add-on](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/)
     will be compatible with Thunderbird 60.5.0.'
   tag: new
-  bug: 1511950
+  bugs:
+  - 1511950
 - note: 'Decoding problems for messages with less common charsets (cp932, cp936)'
   tag: fixed
-  bug: 1511950
+  bugs:
+  - 1511950
 - note: 'New messages in the drafts folder (and other special or virtual folders) will
     no longer be included in the new messages notification'
   tag: fixed
-  bug: 809513
+  bugs:
+  - 809513
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.4">security
     fixes</a>
   tag: fixed
-- note: 'Crash when using custom sound for new email notification. Workaround: Use system sound.'
+- note: 'Crash when using custom sound for new email notification. Workaround: Use system
+    sound.'
   tag: unresolved
-  bug: 1495799
-  bug2: 1482659
+  bugs:
+  - 1495799
+  - 1482659
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+  bugs:
+  - 1512812
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.5.0.yml
+++ b/release/60.5.0.yml
@@ -19,43 +19,56 @@ release:
 notes:
 - note: 'FileLink provider WeTransfer to upload large attachments'
   tag: new
-  bug: 1511950
-- note: 'Thunderbird now allows the addition of OpenSearch search engines from a local XML file
-    using a minimal user inferface: [+] button to select a file an add, [-] to remove.'
+  bugs:
+  - 1511950
+- note: 'Thunderbird now allows the addition of OpenSearch search engines from a local
+    XML file using a minimal user inferface: [+] button to select a file an add, [-] to
+    remove.'
   tag: new
-  bug: 1427317
+  bugs:
+  - 1427317
 - note: 'More search engines: Google and DuckDuckGo available by default in some locales'
   tag: new
-  bug: 1427133
-- note: 'During account creation, Thunderbird will now detect servers using the Microsoft Exchange protocol.
-    It will offer the installation of a 3rd party add-on (Owl) which supports that protocol.'
+  bugs:
+  - 1427133
+- note: 'During account creation, Thunderbird will now detect servers using the Microsoft
+    Exchange protocol. It will offer the installation of a 3rd party add-on (Owl) which
+    supports that protocol.'
   tag: new
-  bug: 1500105
+  bugs:
+  - 1500105
 - note: 'Thunderbird now compatible with other WebExtension-based FileLink add-ons like
-      the [Dropbox add-on](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/)'
+    the [Dropbox add-on](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/)'
   tag: fixed
-  bug: 1511943
+  bugs:
+  - 1511943
 - note: 'Crash when using custom sound for new email notification'
   tag: fixed
-  bug: 1495799
-  bug2: 1482659
+  bugs:
+  - 1495799
+  - 1482659
 - note: 'WebExtension-based dictionaries from addons.mozilla.org not working in Thunderbird'
   tag: fixed
-  bug: 1460748
+  bugs:
+  - 1460748
 - note: 'Calendar: Printing of calendars not working'
   tag: fixed
-  bug: 1517155
+  bugs:
+  - 1517155
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.5">security
     fixes</a>
   tag: fixed
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
-- note: 'CalDav access to some servers not working.
-    Workaround: Set preference network.cookie.same-site.enabled to false.'
+  bugs:
+  - 1512812
+- note: 'CalDav access to some servers not working. Workaround: Set preference network.cookie.same-site.enabled
+    to false.'
   tag: unresolved
-  bug: 1468912
+  bugs:
+  - 1468912
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.5.1.yml
+++ b/release/60.5.1.yml
@@ -19,14 +19,17 @@ release:
 notes:
 - note: 'CalDav access to some servers not working'
   tag: fixed
-  bug: 1468912
+  bugs:
+  - 1468912
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.5.1">security
     fixes</a>
   tag: fixed
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.5.2.yml
+++ b/release/60.5.2.yml
@@ -17,32 +17,40 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Crash when using "Send to > Mail recipient" on Windows under some circumstances (MAPI interface)'
+- note: 'Crash when using "Send to > Mail recipient" on Windows under some circumstances
+    (MAPI interface)'
   tag: fixed
-  bug: 393302
+  bugs:
+  - 393302
 - note: 'UTF-8 support for MAPISendMail'
   tag: fixed
-  bug: 1521007
-- note: 'Problem with S/MIME certificate verification when receiving email from Outlook (issue introduced
-    in version 60.5.1)'
-  bug: 1528615
+  bugs:
+  - 1521007
+- note: 'Problem with S/MIME certificate verification when receiving email from Outlook
+    (issue introduced in version 60.5.1)'
+  bugs:
+  - 1528615
   tag: fixed
-- note: 'Changes to the MAPI interface have caused problems when sending a file from the Windows desktop or a folder
-    via "Sent to > Mail recipient" or via an external application like an office package, for example LibreOffice.
-    To solve this problem, reinstall Thunderbird 60.5.2 from one of these locations:<br>
-    [https://www.thunderbird.net/en-US/thunderbird/all/](https://www.thunderbird.net/en-US/thunderbird/all/)<br>
+- note: 'Changes to the MAPI interface have caused problems when sending a file from the
+    Windows desktop or a folder via "Sent to > Mail recipient" or via an external application
+    like an office package, for example LibreOffice. To solve this problem, reinstall Thunderbird
+    60.5.2 from one of these locations:<br> [https://www.thunderbird.net/en-US/thunderbird/all/](https://www.thunderbird.net/en-US/thunderbird/all/)<br>
     [http://ftp.mozilla.org/pub/thunderbird/releases/60.5.2/win32/](http://ftp.mozilla.org/pub/thunderbird/releases/60.5.2/win32/)<br>
-    [http://ftp.mozilla.org/pub/thunderbird/releases/60.5.2/win64/](http://ftp.mozilla.org/pub/thunderbird/releases/60.5.2/win64/) (unsupported 64bit version).<br>
-    Files with non-ASCII characters in their name also cause a malfunction. Two alternative workarounds exist:<br>
-    <ul>
-    <li>On Windows 10, set the system code page to UTF-8 (beta feature, see Region Settings, system locale)</li>
-    <li>Reset this registry entry<br>HKLM\SOFTWARE\Clients\Mail\Mozilla Thunderbird - SupportUTF8 to 0</li></ul>'
+    [http://ftp.mozilla.org/pub/thunderbird/releases/60.5.2/win64/](http://ftp.mozilla.org/pub/thunderbird/releases/60.5.2/win64/)
+    (unsupported 64bit version).<br> Files with non-ASCII characters in their name also
+    cause a malfunction. Two alternative workarounds exist:<br> <ul> <li>On Windows 10,
+    set the system code page to UTF-8 (beta feature, see Region Settings, system locale)</li>
+    <li>Reset this registry entry<br>HKLM\SOFTWARE\Clients\Mail\Mozilla Thunderbird - SupportUTF8
+    to 0</li></ul>'
   tag: unresolved
-  bug: 393302
+  bugs:
+  - 393302
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.5.3.yml
+++ b/release/60.5.3.yml
@@ -17,19 +17,23 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Problem when using "Send to > Mail recipient" on Windows introduced in version 60.5.2.<br>
-    If files with non-ASCII characters in their name still cause a malfunction, use one of the following two alternative solutions:<br>
-    <ul>
-    <li>Reset this registry entry<br>HKLM\SOFTWARE\Clients\Mail\Mozilla Thunderbird - SupportUTF8 to 0. Also reset HKLM\SOFTWARE\Wow6432Node\Clients\Mail\Mozilla Thunderbird - SupportUTF8 if present.</li>
-    <li>On Windows 10, set the system code page to UTF-8 (beta feature, see Region Settings, system locale)</li>
-    </ul>'
+- note: 'Problem when using "Send to > Mail recipient" on Windows introduced in version
+    60.5.2.<br> If files with non-ASCII characters in their name still cause a malfunction,
+    use one of the following two alternative solutions:<br> <ul> <li>Reset this registry
+    entry<br>HKLM\SOFTWARE\Clients\Mail\Mozilla Thunderbird - SupportUTF8 to 0. Also reset
+    HKLM\SOFTWARE\Wow6432Node\Clients\Mail\Mozilla Thunderbird - SupportUTF8 if present.</li>
+    <li>On Windows 10, set the system code page to UTF-8 (beta feature, see Region Settings,
+    system locale)</li> </ul>'
   tag: fixed
-  bug: 1531724
-  bug2: 1531869
+  bugs:
+  - 1531724
+  - 1531869
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.6.0.yml
+++ b/release/60.6.0.yml
@@ -17,13 +17,17 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Calendar: Can''t create repeating event with end date when using certain time zones, for example Europe/Minsk'
+- note: 'Calendar: Can''t create repeating event with end date when using certain time
+    zones, for example Europe/Minsk'
   tag: fixed
-  bug: 1503731
+  bugs:
+  - 1503731
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.6.1.yml
+++ b/release/60.6.1.yml
@@ -23,7 +23,9 @@ notes:
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.7.0.yml
+++ b/release/60.7.0.yml
@@ -17,16 +17,20 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Attachment pane of Write window no longer focussed when attaching files using a keyboard shortcut'
+- note: 'Attachment pane of Write window no longer focussed when attaching files using
+    a keyboard shortcut'
   tag: changed
-  bug: 1519328
+  bugs:
+  - 1519328
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.7">security
     fixes</a>
   tag: fixed
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.7.1.yml
+++ b/release/60.7.1.yml
@@ -19,14 +19,17 @@ release:
 notes:
 - note: 'No prompt for smartcard PIN when S/MIME signing is used'
   tag: fixed
-  bug: 1519093
+  bugs:
+  - 1519093
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.7.1">security
     fixes</a>
   tag: fixed
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.7.2.yml
+++ b/release/60.7.2.yml
@@ -23,7 +23,9 @@ notes:
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.8.0.yml
+++ b/release/60.8.0.yml
@@ -17,17 +17,21 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Calendar: Problems when editing event times, some related to AM/PM setting in non-English locales'
+- note: 'Calendar: Problems when editing event times, some related to AM/PM setting in
+    non-English locales'
   tag: changed
-  bug: 1512123
-  bug2: 1517569
+  bugs:
+  - 1512123
+  - 1517569
 - note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.8">security
     fixes</a>
   tag: fixed
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.9.0.yml
+++ b/release/60.9.0.yml
@@ -17,19 +17,20 @@ release:
   import_system_requirements: '60.0beta'
 
 notes:
-- note: 'Offer to configure Exchange accounts for Office365.
-    A third-party add-on is required for this account type.
-    IMAP still exists as alternative.'
+- note: 'Offer to configure Exchange accounts for Office365. A third-party add-on is required
+    for this account type. IMAP still exists as alternative.'
   tag: new
-  bug: 1571772
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.9">security
+  bugs:
+  - 1571772
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird60.9">security
     fixes</a>
   tag: fixed
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/60.9.1.yml
+++ b/release/60.9.1.yml
@@ -19,11 +19,14 @@ release:
 notes:
 - note: 'Problem with Google authentication (OAuth2)'
   tag: fixed
-  bug: 1592407
+  bugs:
+  - 1592407
 - note: 'Due to changes in the Mozilla platform profiles stored on Windows network shares
     addressed via drive letters are now addressed via UNC'
   tag: unresolved
-  bug: 1512812
+  bugs:
+  - 1512812
 - note: 'Chat: Twitter not working due to API changes at Twitter.com'
   tag: unresolved
-  bug: 1445778
+  bugs:
+  - 1445778

--- a/release/68.0.yml
+++ b/release/68.0.yml
@@ -77,7 +77,7 @@ notes:
 - note: 'Run filters periodically. Improved filter logging.'
   tag: new
   bug: 864187
-  bug: 697522
+  bug2: 697522
 - note: 'OAuth2 authentication for Yandex'
   tag: new
   bug: 1559972
@@ -86,7 +86,7 @@ notes:
     needs to be set to false)'
   tag: new
   bug: 1491562
-  bug: 1509977
+  bug2: 1509977
 - note: 'On Windows a 64bit installer and MSI package are now available, see the
     [Thunderbird for Organisations](https://www.thunderbird.net/en-US/organizations/) page for details'
   tag: new
@@ -139,7 +139,7 @@ notes:
   bug: 1493158
   bug2: 1527547
   tag: changed
-- note: 'FileLink: 
+- note: 'FileLink:
     WeTransfer is already included.
     [Dropbox](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/) and
     [Box.com](https://addons.thunderbird.net/en-GB/thunderbird/addon/filelink-provider-for-box/)

--- a/release/68.0.yml
+++ b/release/68.0.yml
@@ -70,176 +70,218 @@ release:
 notes:
 - note: 'File link attachments can now be linked to again instead of uploading them again'
   tag: new
-  bug: 1542991
+  bugs:
+  - 1542991
 - note: 'Mark all folders of an account as read'
   tag: new
-  bug: 317301
+  bugs:
+  - 317301
 - note: 'Run filters periodically. Improved filter logging.'
   tag: new
-  bug: 864187
-  bug2: 697522
+  bugs:
+  - 864187
+  - 697522
 - note: 'OAuth2 authentication for Yandex'
   tag: new
-  bug: 1559972
-- note: 'Language packs can now be selected in the Advanced Options. Preference
-    intl.multilingual.enabled needs to be set (and possily also extensions.langpacks.signatures.required
-    needs to be set to false)'
+  bugs:
+  - 1559972
+- note: 'Language packs can now be selected in the Advanced Options. Preference intl.multilingual.enabled
+    needs to be set (and possily also extensions.langpacks.signatures.required needs to
+    be set to false)'
   tag: new
-  bug: 1491562
-  bug2: 1509977
-- note: 'On Windows a 64bit installer and MSI package are now available, see the
-    [Thunderbird for Organisations](https://www.thunderbird.net/en-US/organizations/) page for details'
+  bugs:
+  - 1491562
+  - 1509977
+- note: 'On Windows a 64bit installer and MSI package are now available, see the [Thunderbird
+    for Organisations](https://www.thunderbird.net/en-US/organizations/) page for details'
   tag: new
-- note: 'Added a policy engine that allows customized Thunderbird deployments in enterprise environments,
-    using Windows Group Policy or a cross-platform JSON file'
+- note: 'Added a policy engine that allows customized Thunderbird deployments in enterprise
+    environments, using Windows Group Policy or a cross-platform JSON file'
   tag: new
-  bug: 1552457
+  bugs:
+  - 1552457
 - note: 'TCP keepalive for IMAP protocol'
   tag: new
-  bug: 1535969
+  bugs:
+  - 1535969
 - note: 'Full Unicode support for MAPI interfaces: New support for MAPISendMailW'
   tag: new
-  bug: 1048658
-- note: 'To protect your profile data against a downgrade,
-    Thunderbird 68 may display a message "You have launched an older version of Thunderbird" and will not
-    allow opening a specific profile. Workaround: start with option --allow-downgrade. See
-    [this support article](https://support.mozilla.org/kb/unable-launch-older-version-profile)
-    for details.'
+  bugs:
+  - 1048658
+- note: 'To protect your profile data against a downgrade, Thunderbird 68 may display a
+    message "You have launched an older version of Thunderbird" and will not allow opening
+    a specific profile. Workaround: start with option --allow-downgrade. See [this support
+    article](https://support.mozilla.org/kb/unable-launch-older-version-profile) for details.'
   tag: new
-  bug: 1535116
-- note: 'Calendar: Time zone data can now include past and future changes.
-    All known time zone changes from 2018 to 2022 are included.'
+  bugs:
+  - 1535116
+- note: 'Calendar: Time zone data can now include past and future changes. All known time
+    zone changes from 2018 to 2022 are included.'
   tag: new
-  bug: 1494160
+  bugs:
+  - 1494160
 - note: 'Chat: In each conversation an individual spellcheck language can be selected now'
   tag: new
-  bug: 1559789
+  bugs:
+  - 1559789
 - note: '**Add-on support: Add-ons are only supported if add-on authors have adapted them**'
   tag: changed
-- note: '** Dictionary support: Only WebExtension dictionaries are supported now.**
-    Both addons.mozilla.org and addons.thunderbird.net now provide WebExtension dictionaries.'
+- note: '** Dictionary support: Only WebExtension dictionaries are supported now.** Both
+    addons.mozilla.org and addons.thunderbird.net now provide WebExtension dictionaries.'
   tag: changed
-- note: '** Theme support: Only WebExtension themes are supported now.**
-    Both addons.mozilla.org and addons.thunderbird.net now provide WebExtension themes.'
+- note: '** Theme support: Only WebExtension themes are supported now.** Both addons.mozilla.org
+    and addons.thunderbird.net now provide WebExtension themes.'
   tag: changed
-- note: 'The stand-alone options window has been removed, all options are now shown in a tab'
+- note: 'The stand-alone options window has been removed, all options are now shown in
+    a tab'
   tag: changed
-  bug: 1465061
+  bugs:
+  - 1465061
 - note: "Changed UI when installing add-ons"
   tag: changed
-  bug: 1496632
-  bug2: 1498967
+  bugs:
+  - 1496632
+  - 1498967
 - note: 'Various theme improvements including a dark message list/thread pane'
   tag: changed
-  bug: 1504187
+  bugs:
+  - 1504187
 - note: 'Application menu aka "Hamburger menu"'
   tag: changed
-  bug: 1546309
+  bugs:
+  - 1546309
 - note: 'Improvements when entering, selecting and removing recipients in the Write window'
-  bug: 1493158
-  bug2: 1527547
+  bugs:
+  - 1493158
+  - 1527547
   tag: changed
-- note: 'FileLink:
-    WeTransfer is already included.
-    [Dropbox](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/) and
-    [Box.com](https://addons.thunderbird.net/en-GB/thunderbird/addon/filelink-provider-for-box/)
+- note: 'FileLink: WeTransfer is already included. [Dropbox](https://addons.thunderbird.net/en-US/thunderbird/addon/cloudfile-provider-for-dropbox/)
+    and [Box.com](https://addons.thunderbird.net/en-GB/thunderbird/addon/filelink-provider-for-box/)
     using the new WebExtensions FileLink API are available as add-ons, amongst others.'
   tag: changed
-  bug: 1511950
-  bug2: 1531595
-- note: 'Text and background colors in the Write window and custom colors for tags are no longer restricted to a
-    fixed 10x7 matrix of HTML colors'
+  bugs:
+  - 1511950
+  - 1531595
+- note: 'Text and background colors in the Write window and custom colors for tags are
+    no longer restricted to a fixed 10x7 matrix of HTML colors'
   tag: changed
-  bug: 1497041
-  bug2: 1495808
+  bugs:
+  - 1497041
+  - 1495808
 - note: 'Composition text and background colors no longer sent by default. New option in
     "Tools > Options, Composition".'
-  bug: 690644
+  bugs:
+  - 690644
   tag: changed
-- note: 'UI improvements for external and detached attachments, now showing as links with new
-    menu option "Open Containing Folder"'
+- note: 'UI improvements for external and detached attachments, now showing as links with
+    new menu option "Open Containing Folder"'
   tag: changed
-  bug: 1345167
+  bugs:
+  - 1345167
 - note: 'Textual attachments (plain text, HTML, XML, etc.) are no longer displayed inline.
     Toggle preference mail.inline_attachments.text to display them inline again.'
   tag: changed
-  bug: 1509709
+  bugs:
+  - 1509709
 - note: 'Improved phishing attempt detection for messages with certain forms'
   tag: changed
-  bug: 1249562
+  bugs:
+  - 1249562
 - note: 'Improvements to scam warnings'
   tag: changed
-  bug: 1476428
-- note: 'Reply to self will now search all identities (default of preference
-    mailnews.reply_to_self_check_all_ident changed to true)'
-  bug: 1511723
+  bugs:
+  - 1476428
+- note: 'Reply to self will now search all identities (default of preference mailnews.reply_to_self_check_all_ident
+    changed to true)'
+  bugs:
+  - 1511723
   tag: changed
 - note: 'Maildir now uses the message ID as file name and "eml" as file extension'
-  bug: 1259040
-  bug2: 1144478
+  bugs:
+  - 1259040
+  - 1144478
   tag: changed
 - note: 'Auto-compact threshold increased from 20 MB to 200 MB'
   tag: changed
-  bug: 1462666
+  bugs:
+  - 1462666
 - note: "Calendar: UI improvements for event dialog"
   tag: changed
-  bug: 1496086
-- note: 'Calendar: Thunderbird''s calendar add-on Lightning now uses the same version numbering scheme'
+  bugs:
+  - 1496086
+- note: 'Calendar: Thunderbird''s calendar add-on Lightning now uses the same version numbering
+    scheme'
   tag: changed
-  bug: 1520365
-- note: 'Thunderbird 68 distrusts most SSL/TLS certificates issued by the
-    Certificate Authorities (CA) with the brand names Symantec, GeoTrust,
-    RapidSSL and Thawte. Consequently, any SSL/TLS connections to servers
-    using an affected certificate will fail. Affected servers must be
-    updated to use a different certificate. If Thunderbird displays an error
-    message which states that an additional policy constraint has failed,
-    you should check if the server uses a certificate issued by one of the
-    mentioned brands. Additional information on Mozilla''s action is
-    available at
-    [here](https://blog.mozilla.org/security/2018/03/12/distrust-symantec-tls-certificates/).'
+  bugs:
+  - 1520365
+- note: 'Thunderbird 68 distrusts most SSL/TLS certificates issued by the Certificate Authorities
+    (CA) with the brand names Symantec, GeoTrust, RapidSSL and Thawte. Consequently, any
+    SSL/TLS connections to servers using an affected certificate will fail. Affected servers
+    must be updated to use a different certificate. If Thunderbird displays an error message
+    which states that an additional policy constraint has failed, you should check if the
+    server uses a certificate issued by one of the mentioned brands. Additional information
+    on Mozilla''s action is available at [here](https://blog.mozilla.org/security/2018/03/12/distrust-symantec-tls-certificates/).'
   tag: changed
 - note: 'Column choice and sort order in "Search Messages" dialog lost after relaunch'
   tag: fixed
-  bug: 297251
+  bugs:
+  - 297251
 - note: 'Global indexer causing high CPU loads under some circumstances'
   tag: fixed
-  bug: 1362483
+  bugs:
+  - 1362483
 - note: 'Tags set on IMAP folders sometimes not visible to other users'
-  bug: 583677
+  bugs:
+  - 583677
   tag: fixed
 - note: '"Contribute" button in add-on details not working'
   tag: fixed
-  bug: 1500895
-- note: 'SMTP password wasn''t removed when account was deleted or server or user name were changed'
+  bugs:
+  - 1500895
+- note: 'SMTP password wasn''t removed when account was deleted or server or user name
+    were changed'
   tag: fixed
-  bug: 1315662
+  bugs:
+  - 1315662
 - note: 'Mbox to Maildir conversion not working if Windows search integration is enabled'
   tag: fixed
-  bug: 1472524
-- note: 'Mails won''t get removed from Trash folder using Maildir.
-    Note: Other deletion issues related to Maildir may still persist.'
+  bugs:
+  - 1472524
+- note: 'Mails won''t get removed from Trash folder using Maildir. Note: Other deletion
+    issues related to Maildir may still persist.'
   tag: fixed
-  bug: 1317117
-- note: 'When sending of a message failed due a security issue, only "unknown error" was displayed.
-    Now more details are given.'
+  bugs:
+  - 1317117
+- note: 'When sending of a message failed due a security issue, only "unknown error" was
+    displayed. Now more details are given.'
   tag: fixed
-  bug: 1497488
+  bugs:
+  - 1497488
 - note: 'Improvements of SMTP 5.7.1 message'
   tag: fixed
-  bug: 1195026
-- note: 'Calendar: Multiple connections with different users to the same CalDAV server not working'
+  bugs:
+  - 1195026
+- note: 'Calendar: Multiple connections with different users to the same CalDAV server
+    not working'
   tag: fixed
-  bug: 1544596
+  bugs:
+  - 1544596
 - note: 'Chat: Fixed XMPP authentication when using SASL'
-  bug: 1527480
+  bugs:
+  - 1527480
   tag: fixed
 - note: 'Edit tag not working (will be fixed in version 68.1)'
   tag: unresolved
-  bug: 1578148
-- note: 'Moving messages from "Search Messages" result dialog not working (will be fixed in version 68.1)'
+  bugs:
+  - 1578148
+- note: 'Moving messages from "Search Messages" result dialog not working (will be fixed
+    in version 68.1)'
   tag: unresolved
-  bug: 1577987
-- note: 'Issues with list of content types/actions for incoming attachments (will be fixed in version 68.1)'
+  bugs:
+  - 1577987
+- note: 'Issues with list of content types/actions for incoming attachments (will be fixed
+    in version 68.1)'
   tag: unresolved
-  bug: 1576950
-  bug2: 1576825
+  bugs:
+  - 1576950
+  - 1576825

--- a/release/68.1.0.yml
+++ b/release/68.1.0.yml
@@ -19,49 +19,57 @@ release:
 
   import_system_requirements: '68.0'
 notes:
-- note: 'Offer to configure Exchange accounts for Office365.
-    A third-party add-on is required for this account type.
-    IMAP still exists as alternative.'
+- note: 'Offer to configure Exchange accounts for Office365. A third-party add-on is required
+    for this account type. IMAP still exists as alternative.'
   tag: new
-  bug: 1571772
+  bugs:
+  - 1571772
 - note: 'Edit tag not working'
   tag: fixed
-  bug: 1578148
+  bugs:
+  - 1578148
 - note: 'Write window: "Insert > Characters and Symbols" not working'
   tag: fixed
-  bug: 1578300
+  bugs:
+  - 1578300
 - note: 'Moving/dragging messages from "Search Messages" result dialog not working'
   tag: fixed
-  bug: 1577987
-  bug2: 1577970
+  bugs:
+  - 1577987
+  - 1577970
 - note: 'Command line -compose "attachment=" not working'
   tag: fixed
-  bug: 1577117
+  bugs:
+  - 1577117
 - note: 'Custom views not working'
   tag: fixed
-  bug: 1578029
+  bugs:
+  - 1578029
 - note: 'Issues with list of content types/actions for incoming attachments'
   tag: fixed
-  bug: 1576950
-  bug2: 1576825
-  bug3: 1578591
+  bugs:
+  - 1576950
+  - 1576825
+  - 1578591
 - note: '"Learn More" links in Error Console not working'
   tag: fixed
-  bug: 1427590
-- note: 'Visual glitches: Quick Filter Bar tag buttons too tall,
-    missing scroll bar on Connection Setting subdialog,
-    LDAP server selection after "New", "Edit" and "Delete"'
+  bugs:
+  - 1427590
+- note: 'Visual glitches: Quick Filter Bar tag buttons too tall, missing scroll bar on
+    Connection Setting subdialog, LDAP server selection after "New", "Edit" and "Delete"'
   tag: fixed
-  bug: 1577582
-  bug2: 1577259
-  bug3: 1576365
+  bugs:
+  - 1577582
+  - 1577259
+  - 1576365
 - note: 'Calendar: Parts of CalDAV dialog not working'
   tag: fixed
-  bug: 1577989
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.1">security
+  bugs:
+  - 1577989
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.1">security
     fixes</a>
   tag: fixed
 - note: 'Calendar: Free/busy information in attendees dialog not displayed/scrolled correctly'
   tag: unresolved
-  bug: 1578196
+  bugs:
+  - 1578196

--- a/release/68.1.1.yml
+++ b/release/68.1.1.yml
@@ -21,46 +21,54 @@ release:
 notes:
 - note: 'Issues with attachments in IMAP messages'
   tag: fixed
-  bug: 1579341
-- note: 'Gmail accounts ignored a non-standard trash folder selection.
-    Note: If non-standard trash folder was selected previously in the account settings,
-    this setting will now take effect which may be unexpected.'
+  bugs:
+  - 1579341
+- note: 'Gmail accounts ignored a non-standard trash folder selection. Note: If non-standard
+    trash folder was selected previously in the account settings, this setting will now
+    take effect which may be unexpected.'
   tag: fixed
-  bug: 1578148
-- note: 'Entering/pasting lists of recipients into the addressing widget or
-    mailing list not working reliably, especially when lists contained multiple commas
-    or semicolons'
+  bugs:
+  - 1578148
+- note: 'Entering/pasting lists of recipients into the addressing widget or mailing list
+    not working reliably, especially when lists contained multiple commas or semicolons'
   tag: fixed
-  bug: 1575046
-  bug2: 1336785
-  bug3: 1059988
+  bugs:
+  - 1575046
+  - 1336785
+  - 1059988
 - note: 'Edit mailing list not working'
   tag: fixed
-  bug: 1575046
+  bugs:
+  - 1575046
 - note: 'Various theme fixes, especially dark theme improvements for Calendar'
   tag: fixed
-  bug: 1579411
-  bug2: 1577310
-  bug3: 1577591
-  bug4: 1582564
-  bug5: 1582830
+  bugs:
+  - 1579411
+  - 1577310
+  - 1577591
+  - 1582564
+  - 1582830
 - note: 'Contrast between tag label and background not optimal'
   tag: fixed
-  bug: 1579364
+  bugs:
+  - 1579364
 - note: 'Account Central pane always loaded at start-up'
   tag: fixed
-  bug: 1579575
+  bugs:
+  - 1579575
 - note: '"Config Editor" button not removed if blocked by policy'
   tag: fixed
-  bug: 1579019
-- note: 'Calendar: Free/busy information in attendees dialog not scrolled correctly.
-    Note: Scroll arrows still not behaving correctly.'
+  bugs:
+  - 1579019
+- note: 'Calendar: Free/busy information in attendees dialog not scrolled correctly. Note:
+    Scroll arrows still not behaving correctly.'
   tag: fixed
-  bug: 1579030
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.1.1">security
+  bugs:
+  - 1579030
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.1.1">security
     fixes</a>
   tag: fixed
 - note: 'Calendar: Problems with WCAP provider'
   tag: unresolved
-  bug: 1582746
+  bugs:
+  - 1582746

--- a/release/68.1.1.yml
+++ b/release/68.1.1.yml
@@ -32,11 +32,11 @@ notes:
     or semicolons'
   tag: fixed
   bug: 1575046
-  bug: 1336785
-  bug: 1059988
+  bug2: 1336785
+  bug3: 1059988
 - note: 'Edit mailing list not working'
   tag: fixed
-  bug: 1575046 
+  bug: 1575046
 - note: 'Various theme fixes, especially dark theme improvements for Calendar'
   tag: fixed
   bug: 1579411

--- a/release/68.1.2.yml
+++ b/release/68.1.2.yml
@@ -19,34 +19,43 @@ release:
 
   import_system_requirements: '68.0'
 notes:
-- note: 'Visual glitches: Missing context menu in filter, downloads, password manager and Config Editor search boxes,
-    unwanted scrollbars and cut-off text in Account Manager,
+- note: 'Visual glitches: Missing context menu in filter, downloads, password manager and
+    Config Editor search boxes, unwanted scrollbars and cut-off text in Account Manager,
     incorrect colors in Calendar agenda scrollbars, theme issues on Windows 7'
   tag: fixed
-  bug: 1584720
-  bug2: 1584697
-  bug3: 1582830
-  bug4: 1585300
-  bug5: 1584487
+  bugs:
+  - 1584720
+  - 1584697
+  - 1582830
+  - 1585300
+  - 1584487
 - note: 'Some attachments couldn''t be opened in messages originating from MS Outlook 2016'
   tag: fixed
-  bug: 1584383
+  bugs:
+  - 1584383
 - note: 'Address book import form CSV'
   tag: fixed
-  bug: 1584026
+  bugs:
+  - 1584026
 - note: 'Performance problem in message body search'
   tag: fixed
-  bug: 1584558
-- note: 'Ctrl+Enter to send a message would open an attachment if the attachment pane had focus'
+  bugs:
+  - 1584558
+- note: 'Ctrl+Enter to send a message would open an attachment if the attachment pane had
+    focus'
   tag: fixed
-  bug: 1578450
+  bugs:
+  - 1578450
 - note: 'Calendar: Issues with "Today Pane" start-up'
   tag: fixed
-  bug: 1582746
+  bugs:
+  - 1582746
 - note: 'Calendar: Glitches with custom repeat and reminder number input'
   tag: fixed
-  bug: 1583340
-  bug2: 1583098
+  bugs:
+  - 1583340
+  - 1583098
 - note: 'Calendar: Problems with WCAP provider'
   tag: fixed
-  bug: 1582746
+  bugs:
+  - 1582746

--- a/release/68.1.2.yml
+++ b/release/68.1.2.yml
@@ -46,7 +46,7 @@ notes:
 - note: 'Calendar: Glitches with custom repeat and reminder number input'
   tag: fixed
   bug: 1583340
-  bug: 1583098
+  bug2: 1583098
 - note: 'Calendar: Problems with WCAP provider'
   tag: fixed
   bug: 1582746

--- a/release/68.10.0.yml
+++ b/release/68.10.0.yml
@@ -15,10 +15,12 @@ release:
 notes:
 - note: 'Chat: Topics displayed some characters improperly'
   tag: fixed
-  bug: 1644024
+  bugs:
+  - 1644024
 - note: 'Calendar: Filtering tasks did not work when "Incomplete Tasks" was selected'
   tag: fixed
-  bug: 1593711
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.10">security fixes</a>
+  bugs:
+  - 1593711
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.10">security
+    fixes</a>
   tag: fixed

--- a/release/68.11.0.yml
+++ b/release/68.11.0.yml
@@ -13,9 +13,11 @@ release:
 
 
 notes:
-- note: 'FileLink attachments included as a link and file when added from a network drive via drag & drop'
+- note: 'FileLink attachments included as a link and file when added from a network drive
+    via drag & drop'
   tag: fixed
-  bug: 793118
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.11">security fixes</a>
+  bugs:
+  - 793118
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.11">security
+    fixes</a>
   tag: fixed

--- a/release/68.12.1.yml
+++ b/release/68.12.1.yml
@@ -13,7 +13,8 @@ release:
 
 
 notes:
-- note: 'Thunderbird will no longer automatically install updates when
-      Preferences tab is opened'
+- note: 'Thunderbird will no longer automatically install updates when Preferences tab
+    is opened'
   tag: changed
-  bug: 1666324
+  bugs:
+  - 1666324

--- a/release/68.2.0.yml
+++ b/release/68.2.0.yml
@@ -19,37 +19,47 @@ release:
 notes:
 - note: '[Message Display WebExtension API](https://thunderbird-webextensions.readthedocs.io/en/68/messageDisplay.html)'
   tag: new
-  bug: 1575708
+  bugs:
+  - 1575708
 - note: '[Message Search WebExtension API]( https://thunderbird-webextensions.readthedocs.io/en/68/messages.html#query-queryinfo)'
   tag: new
-  bug: 1531317
+  bugs:
+  - 1531317
 - note: 'Better visual feedback for unread messages when using the dark theme'
   tag: fixed
-  bug: 1588000
+  bugs:
+  - 1588000
 - note: 'Various issues when editing mailing lists'
   tag: fixed
-  bug: 1584211
-  bug2: 1587587
-- note: 'Integration with macOS addressbook and notifications not working after introduction of notarization'
+  bugs:
+  - 1584211
+  - 1587587
+- note: 'Integration with macOS addressbook and notifications not working after introduction
+    of notarization'
   tag: fixed
-  bug: 1586617
+  bugs:
+  - 1586617
 - note: 'Application windows not maintaining their size after restart'
   tag: fixed
-  bug: 1580420
+  bugs:
+  - 1580420
 - note: 'Issues when upgrading from a 32bit version of Thunderbird to a 64bit version.
     Note: If your profile is still not recognised, selected it by visiting about:profiles
     in the Troubleshooting Information.'
   tag: fixed
-  bug: 1587067
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.2">security
+  bugs:
+  - 1587067
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.2">security
     fixes</a>
   tag: fixed
-- note: 'When using a language pack, names of standard folders aren''t localized (will be fixed in TB 68.2.1)'
+- note: 'When using a language pack, names of standard folders aren''t localized (will
+    be fixed in TB 68.2.1)'
   tag: unresolved
-  bug: 1575512
-- note: 'LDAP lookup not working when SSL is enabled. Workaround: Disable SSL or
-    switch off option "Query OSCP responder servers" in the certificate settings in advanced options.'
+  bugs:
+  - 1575512
+- note: 'LDAP lookup not working when SSL is enabled. Workaround: Disable SSL or switch
+    off option "Query OSCP responder servers" in the certificate settings in advanced options.'
   tag: unresolved
-  bug: 1576364
+  bugs:
+  - 1576364
 

--- a/release/68.2.1.yml
+++ b/release/68.2.1.yml
@@ -17,53 +17,64 @@ release:
 
   import_system_requirements: '68.0'
 notes:
-- note: 'A language for the user interface can now be chosen in the advanced settings (multilingual UI)'
+- note: 'A language for the user interface can now be chosen in the advanced settings (multilingual
+    UI)'
   tag: new
-  bug: 1590206
+  bugs:
+  - 1590206
 - note: 'Problem with Google authentication (OAuth2)'
   tag: fixed
-  bug: 1592407
-- note: 'Selected or unread messages not shown in the correct color in the thread pane (message list)
-    under some circumstances'
+  bugs:
+  - 1592407
+- note: 'Selected or unread messages not shown in the correct color in the thread pane
+    (message list) under some circumstances'
   tag: fixed
-  bug: 1585765
+  bugs:
+  - 1585765
 - note: 'When using a language pack, names of standard folders weren''t localized'
   tag: fixed
-  bug: 1575512
+  bugs:
+  - 1575512
 - note: 'Address book default startup directory in preferences panel not persisted'
   tag: fixed
-  bug: 1591364
-- note: 'Various visual glitches: Conditions in filter editor not high enough,
-    folder location widget not showing folder name,
-    problem with menubar customization, add-on home page links accumulating,
-    theme issues on Windows 7'
+  bugs:
+  - 1591364
+- note: 'Various visual glitches: Conditions in filter editor not high enough, folder location
+    widget not showing folder name, problem with menubar customization, add-on home page
+    links accumulating, theme issues on Windows 7'
   tag: fixed
-  bug: 1590666
-  bug2: 1590113
-  bug3: 1590851
-  bug4: 1591693
-  bug5: 1560476
+  bugs:
+  - 1590666
+  - 1590113
+  - 1590851
+  - 1591693
+  - 1560476
 - note: 'Issues when upgrading from a 32bit version of Thunderbird to a 64bit version.
     Note: If your profile is still not recognised, select it by visiting about:profiles
     in the Troubleshooting Information.'
   tag: fixed
-  bug: 1587067
+  bugs:
+  - 1587067
 - note: 'Chat: Extended context menu on Instant messaging status dialog (Show Accounts)'
   tag: fixed
-  bug: 1591506
-- note: 'Then upgrading a 64bit version of Thunderbird version 60 to version 68,
-    a new profile will be created.
-    Workaround: Select the correct profile by visiting about:profiles in the Troubleshooting Information.'
+  bugs:
+  - 1591506
+- note: 'Then upgrading a 64bit version of Thunderbird version 60 to version 68, a new
+    profile will be created. Workaround: Select the correct profile by visiting about:profiles
+    in the Troubleshooting Information.'
   tag: unresolved
-  bug: 1593540
+  bugs:
+  - 1593540
 - note: 'When upgrading from Thunderbird version 60 to version 68, add-ons are not automatically
-    updated during the upgrade process. They will however be updated during the add-on update
-    check. It is of course possible to reinstall compatible add-ons via the Add-ons Manager
-    or via [addons.thunderbird.net](https://addons.thunderbird.net).'
+    updated during the upgrade process. They will however be updated during the add-on
+    update check. It is of course possible to reinstall compatible add-ons via the Add-ons
+    Manager or via [addons.thunderbird.net](https://addons.thunderbird.net).'
   tag: unresolved
-  bug: 1574183
-- note: 'LDAP lookup not working when SSL is enabled. Workaround: Disable SSL or
-    switch off option "Query OSCP responder servers" in the certificate settings in advanced options.'
+  bugs:
+  - 1574183
+- note: 'LDAP lookup not working when SSL is enabled. Workaround: Disable SSL or switch
+    off option "Query OSCP responder servers" in the certificate settings in advanced options.'
   tag: unresolved
-  bug: 1576364
+  bugs:
+  - 1576364
 

--- a/release/68.2.2.yml
+++ b/release/68.2.2.yml
@@ -20,20 +20,23 @@ release:
 
   import_system_requirements: '68.0'
 notes:
-- note: 'When upgrading a 64bit version of Thunderbird version 60 to version 68,
-    the existing profile wasn''t recognized and a new profile was created.<br>
-    Note: If your profile is still not recognized, select it by visiting about:profiles
-    in the Troubleshooting Information.'
+- note: 'When upgrading a 64bit version of Thunderbird version 60 to version 68, the existing
+    profile wasn''t recognized and a new profile was created.<br> Note: If your profile
+    is still not recognized, select it by visiting about:profiles in the Troubleshooting
+    Information.'
   tag: fixed
-  bug: 1593540
+  bugs:
+  - 1593540
 - note: 'When upgrading from Thunderbird version 60 to version 68, add-ons are not automatically
-    updated during the upgrade process. They will however be updated during the add-on update
-    check. It is of course possible to reinstall compatible add-ons via the Add-ons Manager
-    or via [addons.thunderbird.net](https://addons.thunderbird.net).'
+    updated during the upgrade process. They will however be updated during the add-on
+    update check. It is of course possible to reinstall compatible add-ons via the Add-ons
+    Manager or via [addons.thunderbird.net](https://addons.thunderbird.net).'
   tag: unresolved
-  bug: 1574183
-- note: 'LDAP lookup not working when SSL is enabled. Workaround: Disable SSL or
-    switch off option "Query OSCP responder servers" in the certificate settings in advanced options.'
+  bugs:
+  - 1574183
+- note: 'LDAP lookup not working when SSL is enabled. Workaround: Disable SSL or switch
+    off option "Query OSCP responder servers" in the certificate settings in advanced options.'
   tag: unresolved
-  bug: 1576364
+  bugs:
+  - 1576364
 

--- a/release/68.3.0.yml
+++ b/release/68.3.0.yml
@@ -19,42 +19,55 @@ release:
 notes:
 - note: '[Message display toolbar action WebExtension API](https://thunderbird-webextensions.readthedocs.io/en/68/messageDisplayAction.html)'
   tag: new
-  bug: 1531597
-- note: 'Navigation buttons are now available in content tabs, for example those opened via an add-on search'
+  bugs:
+  - 1531597
+- note: 'Navigation buttons are now available in content tabs, for example those opened
+    via an add-on search'
   tag: new
-  bug: 787683
+  bugs:
+  - 787683
 - note: '"New email" icon in Windows systray changed from in-tray with arrow to envelope'
   tag: changed
-  bug: 1594200
+  bugs:
+  - 1594200
 - note: 'Icons of attachments in the attachment pane of the Write window not always correct'
   tag: fixed
-  bug: 1593280
+  bugs:
+  - 1593280
 - note: 'Toolbar buttons of add-ons in the menubar not shown after startup'
   tag: fixed
-  bug: 1584160
-- note: 'LDAP lookup not working when SSL was enabled. LDAP search not working when
-    "All Address Books" was selected.'
+  bugs:
+  - 1584160
+- note: 'LDAP lookup not working when SSL was enabled. LDAP search not working when "All
+    Address Books" was selected.'
   tag: fixed
-  bug: 1576364
+  bugs:
+  - 1576364
 - note: 'Scam link confirmation panel not working'
   tag: fixed
-  bug: 1596413
-- note: 'In Write window, the Link Properties dialog wasn''t showing named anchors in context menu'
+  bugs:
+  - 1596413
+- note: 'In Write window, the Link Properties dialog wasn''t showing named anchors in context
+    menu'
   tag: fixed
-  bug: 1593629
+  bugs:
+  - 1593629
 - note: 'Calendar: Start-up failed if the application menu is not on the calendar toolbars'
   tag: fixed
-  bug: 1588516
-- note: 'Chat: Account reordering via drag-and-drop not working on Instant messaging status dialog (Show Accounts)'
+  bugs:
+  - 1588516
+- note: 'Chat: Account reordering via drag-and-drop not working on Instant messaging status
+    dialog (Show Accounts)'
   tag: fixed
-  bug: 1591505
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.3">security
+  bugs:
+  - 1591505
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.3">security
     fixes</a>
   tag: fixed
 - note: 'When upgrading from Thunderbird version 60 to version 68, add-ons are not automatically
-    updated during the upgrade process. They will however be updated during the add-on update
-    check. It is of course possible to reinstall compatible add-ons via the Add-ons Manager
-    or via [addons.thunderbird.net](https://addons.thunderbird.net).'
+    updated during the upgrade process. They will however be updated during the add-on
+    update check. It is of course possible to reinstall compatible add-ons via the Add-ons
+    Manager or via [addons.thunderbird.net](https://addons.thunderbird.net).'
   tag: unresolved
-  bug: 1574183
+  bugs:
+  - 1574183

--- a/release/68.3.1.yml
+++ b/release/68.3.1.yml
@@ -17,32 +17,41 @@ release:
 
   import_system_requirements: '68.0'
 notes:
-- note: 'In dark theme unread messages no longer shown in blue to distinguish from tagged messages'
+- note: 'In dark theme unread messages no longer shown in blue to distinguish from tagged
+    messages'
   tag: changed
-  bug: 1596702
+  bugs:
+  - 1596702
 - note: 'Account setup is now using client side DNS MX lookup instead of relying on a server.'
   tag: changed
-  bug: 1349337
-  bug2: 1573564
+  bugs:
+  - 1349337
+  - 1573564
 - note: 'Searching LDAP address book crashed in some circumstances'
   tag: fixed
-  bug: 1601389
+  bugs:
+  - 1601389
 - note: 'Message navigation with backward and forward buttons did not work in some circumstances'
   tag: fixed
-  bug: 533504
-  bug2: 1600500
+  bugs:
+  - 533504
+  - 1600500
 - note: 'WebExtension toolbar icons were displayed too small'
   tag: fixed
-  bug: 1598955
+  bugs:
+  - 1598955
 - note: 'Calendar: Tasks due today were not listed in bold'
   tag: fixed
-  bug: 1598885
+  bugs:
+  - 1598885
 - note: 'Calendar: Last day of long-running events was not shown'
   tag: fixed
-  bug: 1572964
+  bugs:
+  - 1572964
 - note: 'When upgrading from Thunderbird version 60 to version 68, add-ons are not automatically
-    updated during the upgrade process. They will however be updated during the add-on update
-    check. It is of course possible to reinstall compatible add-ons via the Add-ons Manager
-    or via [addons.thunderbird.net](https://addons.thunderbird.net).'
+    updated during the upgrade process. They will however be updated during the add-on
+    update check. It is of course possible to reinstall compatible add-ons via the Add-ons
+    Manager or via [addons.thunderbird.net](https://addons.thunderbird.net).'
   tag: unresolved
-  bug: 1574183
+  bugs:
+  - 1574183

--- a/release/68.4.1.yml
+++ b/release/68.4.1.yml
@@ -19,37 +19,46 @@ release:
   import_system_requirements: '68.0'
 notes:
 - note: 'Various improvements when setting up an account for a Microsoft Exchange server:
-    Now offers IMAP/SMTP if available, better detection for Office 365 accounts; re-run configuration after password change.'
+    Now offers IMAP/SMTP if available, better detection for Office 365 accounts; re-run
+    configuration after password change.'
   tag: changed
-  bug: 1592258
-  bug2: 1598861
-  bug3: 1600954
-- note: 'Attachments with one or more spaces in their names couldn''t be opened under some circumstances'
+  bugs:
+  - 1592258
+  - 1598861
+  - 1600954
+- note: 'Attachments with one or more spaces in their names couldn''t be opened under some
+    circumstances'
   tag: fixed
-  bug: 1601905
-- note: 'After changing view layout, the message display pane showed garbled content under some circumstances'
+  bugs:
+  - 1601905
+- note: 'After changing view layout, the message display pane showed garbled content under
+    some circumstances'
   tag: fixed
-  bug: 265393
+  bugs:
+  - 265393
 - note: 'Tags were lost on messages in shared IMAP folders under some circumstances'
   tag: fixed
-  bug: 1596371
-- note: 'Various theme changes to achieve "pixel perfection": Unread icon, "no results" icon,
-    paragraph format and font selector, background of folder summary tooltip'
+  bugs:
+  - 1596371
+- note: 'Various theme changes to achieve "pixel perfection": Unread icon, "no results"
+    icon, paragraph format and font selector, background of folder summary tooltip'
   tag: fixed
-  bug: 1605612
-  bug2: 1605613
-  bug3: 1606249
-  bug4: 1602941
+  bugs:
+  - 1605612
+  - 1605613
+  - 1606249
+  - 1602941
 - note: 'Calendar: Event attendee dialog was not displayed correctly'
   tag: fixed
-  bug: 1604797
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.4.1">security
+  bugs:
+  - 1604797
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.4.1">security
     fixes</a>
   tag: fixed
 - note: 'When upgrading from Thunderbird version 60 to version 68, add-ons are not automatically
-    updated during the upgrade process. They will however be updated during the add-on update
-    check. It is of course possible to reinstall compatible add-ons via the Add-ons Manager
-    or via [addons.thunderbird.net](https://addons.thunderbird.net).'
+    updated during the upgrade process. They will however be updated during the add-on
+    update check. It is of course possible to reinstall compatible add-ons via the Add-ons
+    Manager or via [addons.thunderbird.net](https://addons.thunderbird.net).'
   tag: unresolved
-  bug: 1574183
+  bugs:
+  - 1574183

--- a/release/68.4.2.yml
+++ b/release/68.4.2.yml
@@ -19,23 +19,31 @@ release:
 notes:
 - note: 'Calendar: Task and Event tree colours adjusted for the dark theme'
   tag: changed
-  bug: 1608344
+  bugs:
+  - 1608344
 - note: 'Retrieval of S/MIME certificates from LDAP failed'
   tag: fixed
-  bug: 1604773
-- note: 'Address-parsing crash on some IMAP servers when preference mail.imap.use_envelope_cmd was set'
+  bugs:
+  - 1604773
+- note: 'Address-parsing crash on some IMAP servers when preference mail.imap.use_envelope_cmd
+    was set'
   tag: fixed
-  bug: 1609690
+  bugs:
+  - 1609690
 - note: 'Incorrect forwarding of HTML messages caused SMTP servers to respond with a timeout'
   tag: fixed
-  bug: 1222046
-- note: 'Calendar: Various parts of the calendar UI stopped working when a second Thunderbird window opened'
+  bugs:
+  - 1222046
+- note: 'Calendar: Various parts of the calendar UI stopped working when a second Thunderbird
+    window opened'
   tag: fixed
-  bug: 1608407
+  bugs:
+  - 1608407
 
 - note: 'When upgrading from Thunderbird version 60 to version 68, add-ons are not automatically
-    updated during the upgrade process. They will however be updated during the add-on update
-    check. It is of course possible to reinstall compatible add-ons via the Add-ons Manager
-    or via [addons.thunderbird.net](https://addons.thunderbird.net).'
+    updated during the upgrade process. They will however be updated during the add-on
+    update check. It is of course possible to reinstall compatible add-ons via the Add-ons
+    Manager or via [addons.thunderbird.net](https://addons.thunderbird.net).'
   tag: unresolved
-  bug: 1574183
+  bugs:
+  - 1574183

--- a/release/68.5.0.yml
+++ b/release/68.5.0.yml
@@ -20,29 +20,35 @@ release:
 notes:
 - note: 'Support for Client Identity IMAP/SMTP Service Extension'
   tag: new
-  bug: 1532388
+  bugs:
+  - 1532388
 - note: 'Support for OAuth 2.0 authentication for POP3 accounts'
   tag: new
-  bug: 1538409
+  bugs:
+  - 1538409
 - note: 'Status area goes blank during account setup'
   tag: fixed
-  bug: 1593122
+  bugs:
+  - 1593122
 - note: 'Calendar: Could not remove color for default categories'
   tag: fixed
-  bug: 1584853
+  bugs:
+  - 1584853
 - note: 'Calendar: Prevent calendar component loading multiple times'
   tag: fixed
-  bug: 1606375
+  bugs:
+  - 1606375
 - note: 'Calendar: Today pane did not retain width between sessions'
   tag: fixed
-  bug: 1610207
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.5">security
+  bugs:
+  - 1610207
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.5">security
     fixes</a>
   tag: fixed
 - note: 'When upgrading from Thunderbird version 60 to version 68, add-ons are not automatically
-  updated during the upgrade process. They will however be updated during the add-on update
-  check. It is of course possible to reinstall compatible add-ons via the Add-ons Manager
-  or via [addons.thunderbird.net](https://addons.thunderbird.net).'
+    updated during the upgrade process. They will however be updated during the add-on
+    update check. It is of course possible to reinstall compatible add-ons via the Add-ons
+    Manager or via [addons.thunderbird.net](https://addons.thunderbird.net).'
   tag: unresolved
-  bug: 1574183
+  bugs:
+  - 1574183

--- a/release/68.6.0.yml
+++ b/release/68.6.0.yml
@@ -20,18 +20,22 @@ release:
 notes:
 - note: 'Thunderbird now displays a popup window when starting up on a new profile'
   tag: new
-  bug: 1590036
+  bugs:
+  - 1590036
 - note: 'Thunderbird now provides partial updates resulting in smaller downloads'
   tag: changed
-  bug: 1410512
+  bugs:
+  - 1410512
 - note: 'Searching in message bodies led to false negatives under some circumstances in
     quoted-printable encoded HTML bodies'
   tag: fixed
-  bug: 1614796
-- note: '"Get New Messages for All Accounts" not working for OAuth2-authenticated IMAP accounts'
+  bugs:
+  - 1614796
+- note: '"Get New Messages for All Accounts" not working for OAuth2-authenticated IMAP
+    accounts'
   tag: fixed
-  bug: 1593611
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.6">security
+  bugs:
+  - 1593611
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.6">security
     fixes</a>
   tag: fixed

--- a/release/68.7.0.yml
+++ b/release/68.7.0.yml
@@ -20,42 +20,55 @@ release:
 notes:
 - note: 'MailExtensions: Raw message source available to MailExtensions'
   tag: new
-  bug: 1525274
-- note: 'MailExtensions: messages.update function extended to mark messages as junk or not junk'
+  bugs:
+  - 1525274
+- note: 'MailExtensions: messages.update function extended to mark messages as junk or
+    not junk'
   tag: changed
-  bug: 1598332
+  bugs:
+  - 1598332
 - note: 'MailExtensions: browser.compose.begin functions no longer expand mailing lists'
   tag: changed
-  bug: 1612480
+  bugs:
+  - 1612480
 - note: 'Various improvements to account setup when connecting to an Exchange server'
   tag: fixed
-  bug: 1598861
-  bug2: 1611405
+  bugs:
+  - 1598861
+  - 1611405
 - note: 'Thread collapsed when opening news message in a new window'
   tag: fixed
-  bug: 1526765
-- note: 'Addons not automatically updated to compatible version after upgrade from Thunderbird 60'
+  bugs:
+  - 1526765
+- note: 'Addons not automatically updated to compatible version after upgrade from Thunderbird
+    60'
   tag: fixed
-  bug: 1574183
+  bugs:
+  - 1574183
 - note: 'Updating addons did not prompt when requesting new permissions'
   tag: fixed
-  bug: 1620861
+  bugs:
+  - 1620861
 - note: 'Extra recipients panel not keyboard-accessible'
   tag: fixed
-  bug: 1612717
+  bugs:
+  - 1612717
 - note: 'Accessibility: Status bar was not detected by screenreaders'
   tag: fixed
-  bug: 1621287
+  bugs:
+  - 1621287
 - note: 'MailExtensions: messages.query by folder name did not require accountsRead permission'
   tag: fixed
-  bug: 1625793
+  bugs:
+  - 1625793
 - note: 'Calendar: Invitations with embedded null bytes did not always decode correctly'
   tag: fixed
-  bug: 1623896
+  bugs:
+  - 1623896
 - note: 'Calendar: Cancelled events didn''t show with a line-through'
   tag: fixed
-  bug: 1621210
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.7">security
+  bugs:
+  - 1621210
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.7">security
     fixes</a>
   tag: fixed

--- a/release/68.8.0.yml
+++ b/release/68.8.0.yml
@@ -20,27 +20,32 @@ release:
 notes:
 - note: 'Account Manager: text fields were too small in some cases'
   tag: fixed
-  bug: 1616387
+  bugs:
+  - 1616387
 - note: 'Account Manager: Authentication method did not update when selecting an SMTP server'
   tag: fixed
-  bug: 1631437
+  bugs:
+  - 1631437
 - note: 'Links with embedded credentials did not open on Windows'
   tag: fixed
-  bug: 1609451
-- note: 'Messages were sometimes sent with a badly formed address when filled from
-    the address book'
+  bugs:
+  - 1609451
+- note: 'Messages were sometimes sent with a badly formed address when filled from the
+    address book'
   tag: fixed
-  bug: 1629842
-- note: 'Accessibility: Screen readers were reporting too many activities from the
-    status bar'
+  bugs:
+  - 1629842
+- note: 'Accessibility: Screen readers were reporting too many activities from the status
+    bar'
   tag: fixed
-  bug: 1628891
-- note: 'MailExtensions: Setting IMAP messages as read with browser.messages.updated
-    failed to persist'
+  bugs:
+  - 1628891
+- note: 'MailExtensions: Setting IMAP messages as read with browser.messages.updated failed
+    to persist'
   tag: fixed
-  bug: 1631184
+  bugs:
+  - 1631184
 
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.8">security
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.8">security
     fixes</a>
   tag: fixed

--- a/release/68.8.1.yml
+++ b/release/68.8.1.yml
@@ -14,10 +14,13 @@ release:
 notes:
 - note: 'IMAP stability improvements'
   tag: fixed
-  bug: 1586494
+  bugs:
+  - 1586494
 - note: 'HTML tags in IRC topic changes were rendered incorrectly'
   tag: fixed
-  bug: 1607097
+  bugs:
+  - 1607097
 - note: 'MailExtensions: Websockets could not be used'
   tag: fixed
-  bug: 1627649
+  bugs:
+  - 1627649

--- a/release/68.9.0.yml
+++ b/release/68.9.0.yml
@@ -14,15 +14,17 @@ release:
 notes:
 - note: 'Custom headers added for searching or filtering could not be removed'
   tag: fixed
-  bug: 1631577
+  bugs:
+  - 1631577
 - note: 'Calendar: Today Pane updated prior to loading all data'
   tag: fixed
-  bug: 1635613
+  bugs:
+  - 1635613
 - note: 'Stability improvements'
   tag: fixed
-  bug: 1625677
-  bug2: 1629204
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.9">security
+  bugs:
+  - 1625677
+  - 1629204
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.9">security
     fixes</a>
   tag: fixed

--- a/release/78.0.1.yml
+++ b/release/78.0.1.yml
@@ -26,44 +26,58 @@ release:
 notes:
 - note: 'OpenPGP: Key revocation, extending key expiration, and secret key backup'
   tag: new
-  bug: 1651712
+  bugs:
+  - 1651712
 - note: 'Drag & Drop multiple attachments to macOS Finder created duplicate files'
   tag: fixed
-  bug: 1494588
+  bugs:
+  - 1494588
 - note: 'Faceted search date and relevance settings not saved'
   tag: fixed
-  bug: 663859
-- note: 'FileLink attachments included as a link and file when added from a network drive via drag & drop'
+  bugs:
+  - 663859
+- note: 'FileLink attachments included as a link and file when added from a network drive
+    via drag & drop'
   tag: fixed
-  bug: 793118
+  bugs:
+  - 793118
 - note: 'About Thunderbird dialog keyboard shortcuts did not work'
   tag: fixed
-  bug: 1638563
+  bugs:
+  - 1638563
 - note: 'CC''d recipients sometimes displayed collapsed in header pane'
   tag: fixed
-  bug: 1652410
-- note: 'Incremental search in contacts sidebar did not always display local results when an LDAP server was also in use'
+  bugs:
+  - 1652410
+- note: 'Incremental search in contacts sidebar did not always display local results when
+    an LDAP server was also in use'
   tag: fixed
-  bug: 1644026
+  bugs:
+  - 1644026
 - note: 'Contacts sidebar search results cleared after removing a contact'
   tag: fixed
-  bug: 1644084
+  bugs:
+  - 1644084
 - note: 'OpenPGP: Messages with long Armor Header lines did not display'
   tag: fixed
-  bug: 1653651
+  bugs:
+  - 1653651
 - note: 'OpenPGP: Messages containing non-UTF-8 text were not supported'
   tag: fixed
-  bug: 1651896
+  bugs:
+  - 1651896
 - note: 'Various UI and theming fixes'
   tag: fixed
-  bug: 1649577
-  bug2: 1650240
-  bug3: 1650789
-  bug4: 1650791
-  bug5: 1652199
-  bug6: 1652015
-  bug7: 1651472
-  bug8: 1653628
+  bugs:
+  - 1649577
+  - 1650240
+  - 1650789
+  - 1650791
+  - 1652199
+  - 1652015
+  - 1651472
+  - 1653628
 - note: 'Chat: Participants list did not display operator flags'
   tag: fixed
-  bug: 1648585
+  bugs:
+  - 1648585

--- a/release/78.0.yml
+++ b/release/78.0.yml
@@ -75,235 +75,287 @@ release:
 notes:
 - note: New Account Hub for centralized account setup
   tag: new
-  bug: 1589005
+  bugs:
+  - 1589005
 - note: 'Redesigned recipient address fields (To, Cc, Bcc) as single-line input fields
-    (pills) for multiple addresses instead of one line per address. *More improvements to come.*'
+    (pills) for multiple addresses instead of one line per address. *More improvements
+    to come.*'
   tag: new
-  bug: 440377
-  bug2: 1609647
-  bug3: 1615917
-  bug4: 1603166
-  bug5: 1602477
+  bugs:
+  - 440377
+  - 1609647
+  - 1615917
+  - 1603166
+  - 1602477
 - note: Color customization of Folder Pane icons
   tag: new
-  bug: 1637668
-- note: Allow selecting messages via selection boxes instead of classic selection.
-    "Select Messages" column needs to be selected via the thread pane's column picker.
+  bugs:
+  - 1637668
+- note: Allow selecting messages via selection boxes instead of classic selection. "Select
+    Messages" column needs to be selected via the thread pane's column picker.
   tag: new
-  bug: 1017904
+  bugs:
+  - 1017904
 - note: '"Delete" action column in thread pane (message list). "Select Messages" column
     needs to be selected via the thread pane''s column picker.'
   tag: new
-  bug: 1626841
+  bugs:
+  - 1626841
 - note: Themes can be previewed in the Add-On Manager
   tag: new
-  bug: 1598903
+  bugs:
+  - 1598903
 - note: Minimize to tray support added for Windows
   tag: new
-  bug: 208923
-  bug2: 1626161
+  bugs:
+  - 208923
+  - 1626161
 - note: New config option to anonymize message date header
   tag: new
-  bug: 1603359
+  bugs:
+  - 1603359
 - note: Global Search menu item in app menu
   tag: new
-  bug: 1356792
+  bugs:
+  - 1356792
 - note: 'Additional Enterprise policies'
   tag: new
-  bug: 1622703
-  bug2: 1628156
+  bugs:
+  - 1622703
+  - 1628156
 - note: 'Calendar: Added ICS import support to -file command line option'
   tag: new
-  bug: 1583595
+  bugs:
+  - 1583595
 - note: 'Calendar: Add event preview to ICS import dialog'
   tag: new
-  bug: 1631902
+  bugs:
+  - 1631902
 - note: 'Chat: OTR messaging support'
   tag: new
-  bug: 1518166
+  bugs:
+  - 1518166
 - note: 'Chat: IRC echo-message capability'
   tag: new
-  bug: 1601102
+  bugs:
+  - 1601102
 
 - note: '**Add-on support: As of version 78.0, Thunderbird only supports MailExtensions
-    and MailExtension Experiments. Restartless add-ons and non-restartless legacy
-    add-ons using XUL overlays are no longer supported.**'
+    and MailExtension Experiments. Restartless add-ons and non-restartless legacy add-ons
+    using XUL overlays are no longer supported.**'
   tag: changed
-  bug: 1614237
-- note: '**As of version 78.0, "sideloaded" extensions are no longer supported.
-  Enterprise administrators can deploy extensions using policies.'
+  bugs:
+  - 1614237
+- note: '**As of version 78.0, "sideloaded" extensions are no longer supported. Enterprise
+    administrators can deploy extensions using policies.'
   tag: changed
-  bug: 1656652
-- note: 'Linux minimum runtime requirements have changed: GTK 3.14, GLIBC 2.17, libstdc++ 4.8.1
-    [Details](/en-US/thunderbird/78.0/system-requirements/)'
+  bugs:
+  - 1656652
+- note: 'Linux minimum runtime requirements have changed: GTK 3.14, GLIBC 2.17, libstdc++
+    4.8.1 [Details](/en-US/thunderbird/78.0/system-requirements/)'
   tag: changed
-  bug: 1634204
+  bugs:
+  - 1634204
 - note: Thunderbird Options/Preferences tab redesigned and with new user interface
   tag: changed
-  bug: 1498332
+  bugs:
+  - 1498332
 - note: Account creation dialog redesigned and with new user interface
   tag: changed
-  bug: 1551133
-  bug2: 1590636
-  bug3: 1590636
+  bugs:
+  - 1551133
+  - 1590636
+  - 1590636
 - note: Account Manager moved to a tab
   tag: changed
-  bug: 1610445
-  bug2: 1628497
+  bugs:
+  - 1610445
+  - 1628497
 - note: Add-ons manager with new user interface and notifications
   tag: changed
-  bug: 1566347
-  bug2: 1621841
-  bug3: 1621213
-  bug4: 1600923
-- note: Improved "Recent" folder list for "Move to" and "Copy to" in message context
-    menu
+  bugs:
+  - 1566347
+  - 1621841
+  - 1621213
+  - 1600923
+- note: Improved "Recent" folder list for "Move to" and "Copy to" in message context menu
   tag: changed
-  bug: 949135
+  bugs:
+  - 949135
 - note: Improved UI of global search results tab
   tag: changed
-  bug: 1022228
+  bugs:
+  - 1022228
 - note: Improvements to the location bar of a tab displaying web pages
   tag: changed
-  bug: 1644689
+  bugs:
+  - 1644689
 - note: 'Use scalable icons throughout Thunderbird to improve support for HiDPI monitors
     and dark mode'
   tag: changed
-  bug: 1636238
-  bug2: 1638863
-- note: Address books are now stored as SQLite databases to prepare for future
-    addressbook improvements. Existing address books in MAB format (using a Mork database)
-    will be converted.
+  bugs:
+  - 1636238
+  - 1638863
+- note: Address books are now stored as SQLite databases to prepare for future addressbook
+    improvements. Existing address books in MAB format (using a Mork database) will be
+    converted.
   tag: changed
-  bug: 1572324
-  bug2: 1576525
-  bug3: 1581765
-  bug4: 1606285
-  bug5: 1606284
+  bugs:
+  - 1572324
+  - 1576525
+  - 1581765
+  - 1606285
+  - 1606284
 - note: New parser and formatter for vCard. vCard versions 3.0 and 4.0 are now supported.
   tag: changed
-  bug: 1639430
+  bugs:
+  - 1639430
 - note: Various theme and dark mode improvements
   tag: changed
-  bug: 1627748
-  bug2: 1629084
-  bug3: 1629515
-  bug4: 1629518
-  bug5: 1630985
-  bug6: 1631779
-  bug7: 1619725
-  bug8: 1640390
-  bug9: 1591531
+  bugs:
+  - 1627748
+  - 1629084
+  - 1629515
+  - 1629518
+  - 1630985
+  - 1631779
+  - 1619725
+  - 1640390
+  - 1591531
 - note: Various look and feel improvements
   tag: changed
-  bug: 1514863
-  bug2: 1643159
-  bug3: 1644730
-  bug4: 1644798
-  bug5: 1645094
-  bug6: 1645687
-  bug7: 1645700
-  bug8: 1647471
-  bug9: 1647479
+  bugs:
+  - 1514863
+  - 1643159
+  - 1644730
+  - 1644798
+  - 1645094
+  - 1645687
+  - 1645700
+  - 1647471
+  - 1647479
 - note: Improved dialog for folder compaction (purging of deleted messages)
   tag: changed
-  bug: 716412
+  bugs:
+  - 716412
 - note: Graphics hardware acceleration is now enabled by default
   tag: changed
-  bug: 1623265
+  bugs:
+  - 1623265
 - note: TLS 1.0 and 1.1 disabled
   tag: changed
-  bug: 1606733
+  bugs:
+  - 1606733
 - note: 'Calendar: The Lightning calendar add-on is now integrated into Thunderbird'
   tag: changed
-  bug: 1608610
+  bugs:
+  - 1608610
 - note: 'Calendar: Lightning version removed from Thunderbird user agent string'
   tag: changed
-  bug: 1624241
+  bugs:
+  - 1624241
 - note: 'Calendar: Web Calendar Access Protocol (WCAP) support removed'
   tag: changed
-  bug: 1579020
+  bugs:
+  - 1579020
 - note: 'Calendar: Storage access is now asynchronous to improve performance'
   tag: changed
-  bug: 501689
+  bugs:
+  - 501689
 - note: 'Calendar: Location URLs are now clickable'
   tag: changed
-  bug: 1614972
-- note: 'Addon Developers: Updates to and expansion of MailExtensions APIs.
-    [Details](https://developer.thunderbird.net/add-ons/updating/tb78)'
+  bugs:
+  - 1614972
+- note: 'Addon Developers: Updates to and expansion of MailExtensions APIs. [Details](https://developer.thunderbird.net/add-ons/updating/tb78)'
   tag: changed
-  bug: 1532528
-  bug2: 1532528
-  bug3: 1599380
-  bug4: 1531593
-  bug5: 1630786
-  bug6: 1644000
-  bug7: 1645945
+  bugs:
+  - 1532528
+  - 1532528
+  - 1599380
+  - 1531593
+  - 1630786
+  - 1644000
+  - 1645945
 
 - note: Password display font had characters that were difficult to read
   tag: fixed
-  bug: 242418
-- note: When copying messages from an IMAP folder to a local folder, offline store
-    wasn't used
+  bugs:
+  - 242418
+- note: When copying messages from an IMAP folder to a local folder, offline store wasn't
+    used
   tag: fixed
-  bug: 505456
-- note: While Thunderbird was in safe mode, the help menu did not offer an item to
-    restart with add-ons enabled
+  bugs:
+  - 505456
+- note: While Thunderbird was in safe mode, the help menu did not offer an item to restart
+    with add-ons enabled
   tag: fixed
-  bug: 724963
+  bugs:
+  - 724963
 - note: Mailbox quotas not displayed correctly
   tag: fixed
-  bug: 841906
+  bugs:
+  - 841906
 - note: Images not rotated when composing a message
   tag: fixed
-  bug: 1340927
+  bugs:
+  - 1340927
 - note: Email addresses sometimes displayed incorrectly in message composer
   tag: fixed
-  bug: 1526456
+  bugs:
+  - 1526456
 - note: 'Many accessibility fixes and improvements: message composer, account setup, attachment
     pane'
   tag: fixed
-  bug: 1589859
-  bug2: 1613284
-  bug3: 1620310
-  bug4: 1620718
-  bug5: 1637230
-  bug6: 1637536
-  bug7: 1589863
+  bugs:
+  - 1589859
+  - 1613284
+  - 1620310
+  - 1620718
+  - 1637230
+  - 1637536
+  - 1589863
 - note: Mailbox format conversion fixes
   tag: fixed
-  bug: 1515254
-  bug2: 1611897
+  bugs:
+  - 1515254
+  - 1611897
 - note: 'Address book improvements: exporting, editing contacts, contact photos'
   tag: fixed
-  bug: 1619155
-  bug2: 1622642
-  bug3: 1624207
-  bug4: 1624207
-  bug5: 1626167
-  bug6: 1630184
-  bug7: 1633294
+  bugs:
+  - 1619155
+  - 1622642
+  - 1624207
+  - 1624207
+  - 1626167
+  - 1630184
+  - 1633294
 - note: 'Chat: Renaming contacts in context menu did not work'
   tag: fixed
-  bug: 1622000
+  bugs:
+  - 1622000
 - note: 'Calendar: Task and event dialogs were sometimes too small for their content'
   tag: fixed
-  bug: 1623817
+  bugs:
+  - 1623817
 - note: 'Calendar: URLs in the event reminder dialog were not clickable'
   tag: fixed
-  bug: 1644990
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.0">security fixes</a>
+  bugs:
+  - 1644990
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.0">security
+    fixes</a>
   tag: fixed
 
 
 # Unresolved
 - note: 'Mail header toolbar (Reply, Forward, Archive, Junk buttons) no longer configurable'
   tag: unresolved
-  bug: 1556261
+  bugs:
+  - 1556261
 - note: 'Preferences search not available'
-  bug: 1573678
+  bugs:
+  - 1573678
   tag: unresolved
 - note: 'Drag and drop of address book contacts not working in some situations'
-  bug: 1649804
+  bugs:
+  - 1649804
   tag: unresolved

--- a/release/78.1.0.yml
+++ b/release/78.1.0.yml
@@ -26,50 +26,62 @@ release:
   import_system_requirements: '78.0'
 
 notes:
-- note: '**OpenPGP support is now feature complete.** Improvements: new Key Wizard,
-    online searching for OpenPGP keys, and more'
+- note: '**OpenPGP support is now feature complete.** Improvements: new Key Wizard, online
+    searching for OpenPGP keys, and more'
   tag: new
-  bug: 22687
-  bug2: 1652537
-  bug3: 1655113
+  bugs:
+  - 22687
+  - 1652537
+  - 1655113
 - note: 'The preferences tab now has a search field'
   tag: new
-  bug: 1573678
+  bugs:
+  - 1573678
 - note: 'Dark background in message reader is now disabled'
   tag: changed
-  bug: 1639249
+  bugs:
+  - 1639249
 - note: 'Thunderbird startup was slow when using folder color customizations with many
     folders. **Previously configured colors will not be migrated.**'
   tag: fixed
-  bug: 1652279
+  bugs:
+  - 1652279
 - note: 'Mail quota usage in status bar did not support terabyte folder sizes'
   tag: fixed
-  bug: 1636665
+  bugs:
+  - 1636665
 - note: 'Changing Junk mail settings with keyboard toggled wrong setting'
   tag: fixed
-  bug: 1607613
+  bugs:
+  - 1607613
 - note: 'Advanced IMAP server preferences not saved in Account Manager'
   tag: fixed
-  bug: 1653588
+  bugs:
+  - 1653588
 - note: 'Address book migration updates and fixes'
   tag: fixed
-  bug: 1652940
+  bugs:
+  - 1652940
 - note: 'Address book: Last Modified Date was not updated'
   tag: fixed
-  bug: 1634863
+  bugs:
+  - 1634863
 - note: 'Dark mode improvements'
   tag: fixed
-  bug: 1653750
-  bug2: 1653751
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.1">security fixes</a>
+  bugs:
+  - 1653750
+  - 1653751
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.1">security
+    fixes</a>
   tag: fixed
 
 # unresolved
 - note: 'Mail header toolbar (Reply, Forward, Archive, Junk buttons) no longer configurable'
   tag: unresolved
-  bug: 1556261
+  bugs:
+  - 1556261
 - note: 'Fixed width font not working in compose window'
   tag: unresolved
-  bug: 1655279
+  bugs:
+  - 1655279
 

--- a/release/78.1.1.yml
+++ b/release/78.1.1.yml
@@ -28,40 +28,51 @@ release:
 notes:
 - note: 'Building OpenPGP shared library linked to system libraries now supported'
   tag: changed
-  bug: 1634963
+  bugs:
+  - 1634963
 - note: 'MailExtension errors now shown in Developer Tools console by default'
   tag: changed
-  bug: 1650149
+  bugs:
+  - 1650149
 - note: 'MailExtensions: Dynamic registration of calendar providers now supported'
   tag: changed
-  bug: 1652885
+  bugs:
+  - 1652885
 
 
 - note: 'OpenPGP improvements'
   tag: fixed
-  bug: 1655210
+  bugs:
+  - 1655210
 - note: 'Message preview was sometimes blank after upgrading from Thunderbird 68'
   tag: fixed
-  bug: 1653168
+  bugs:
+  - 1653168
 - note: 'Email addresses whitelisted for remote content not displayed in preferences'
-  bug: 1652575
+  bugs:
+  - 1652575
   tag: fixed
 - note: 'Importing data from Seamonkey did not work'
   tag: fixed
-  bug: 272292
+  bugs:
+  - 272292
 - note: 'Renaming a mail list did not update the side bar'
   tag: fixed
-  bug: 1632331
+  bugs:
+  - 1632331
 - note: 'MailExtensions: messenger.* namespace was undefined'
   tag: fixed
-  bug: 1641573
+  bugs:
+  - 1641573
 
 
 
 # unresolved
 - note: 'Mail header toolbar (Reply, Forward, Archive, Junk buttons) no longer configurable'
   tag: unresolved
-  bug: 1556261
+  bugs:
+  - 1556261
 - note: 'Fixed width font not working in compose window'
   tag: unresolved
-  bug: 1655279
+  bugs:
+  - 1655279

--- a/release/78.2.0.yml
+++ b/release/78.2.0.yml
@@ -28,99 +28,125 @@ release:
 notes:
 - note: 'OpenPGP Key generation now disabled when there is no default mail account configured'
   tag: changed
-  bug: 1657497
+  bugs:
+  - 1657497
 - note: 'OpenPGP: Encrypt saved drafts when OpenPGP is enabled'
   tag: changed
-  bug: 1650551
+  bugs:
+  - 1650551
 - note: 'Twitter search removed'
   tag: changed
-  bug: 1653792
+  bugs:
+  - 1653792
 - note: 'Calendar: Event summary dialog is now themeable'
   tag: changed
-  bug: 1659079
-- note: 'MailExtensions: Some APIs now use defineLazyPreferenceGetter in order to
-    benefit from caching'
+  bugs:
+  - 1659079
+- note: 'MailExtensions: Some APIs now use defineLazyPreferenceGetter in order to benefit
+    from caching'
   tag: changed
-  bug: 1658116
+  bugs:
+  - 1658116
 
 - note: 'OpenPGP Key Manager search function did not work'
   tag: fixed
-  bug: 1657894
+  bugs:
+  - 1657894
 - note: 'OpenPGP Key Properties dialog was sometimes too small'
   tag: fixed
-  bug: 1643343
+  bugs:
+  - 1643343
 - note: 'OpenPGP: Encrypted email would not send if address contained uppercase characters'
   tag: fixed
-  bug: 1657390
+  bugs:
+  - 1657390
 - note: 'OpenPGP: "Key ID" column could not be resized in Key Manage'
   tag: fixed
-  bug: 1658512
+  bugs:
+  - 1658512
 - note: 'OpenPGP: Keys containing invalid UTF-8 strings could not be imported'
   tag: fixed
-  bug: 1658730
+  bugs:
+  - 1658730
 - note: 'OpenPGP: Enable automatic signing for encrypted messages in additional scenarios'
   tag: fixed
-  bug: 1659487
+  bugs:
+  - 1659487
 - note: 'Many more OpenPGP bug fixes and improvements'
   tag: fixed
-  bug: 1633251
-  bug2: 1653763
-  bug3: 1656023
-  bug4: 1656391
-  bug5: 1657245
-  bug6: 1657464
+  bugs:
+  - 1633251
+  - 1653763
+  - 1656023
+  - 1656391
+  - 1657245
+  - 1657464
 - note: 'IMAP fetch chunk size was always 65536 bytes'
   tag: fixed
-  bug: 1580480
+  bugs:
+  - 1580480
 - note: 'IMAP server capabilities were not rechecked after upgrading to SSL/TLS connection'
   tag: fixed
-  bug: 1611624
-- note: 'Message Composer: Order of attachments could not be modified using drag &
-    drop'
+  bugs:
+  - 1611624
+- note: 'Message Composer: Order of attachments could not be modified using drag & drop'
   tag: fixed
-  bug: 1658114
+  bugs:
+  - 1658114
 - note: 'Composing messages with a "fixed width" font did not work'
   tag: fixed
-  bug: 1658999
-  bug2: 1655279
+  bugs:
+  - 1658999
+  - 1655279
 - note: 'Drag and drop of address book contacts did not work in some situations'
   tag: fixed
-  bug: 1649804
+  bugs:
+  - 1649804
 - note: 'Address book migration failed when there was a dot in the file name'
   tag: fixed
-  bug: 1655686
-- note: 'Address book: "Always prefer display name over message header" was always
-    checked when editing a contact'
+  bugs:
+  - 1655686
+- note: 'Address book: "Always prefer display name over message header" was always checked
+    when editing a contact'
   tag: fixed
-  bug: 1655884
+  bugs:
+  - 1655884
 - note: 'Address book performance optimizations'
   tag: fixed
-  bug: 1658062
-  bug2: 1658128
+  bugs:
+  - 1658062
+  - 1658128
 - note: 'Dialog to add a new mail account from "Account Settings" did not open'
   tag: fixed
-  bug: 1659241
-- note: '"Select All" (Ctrl+A) in message source did not work until focused with a
-    mouse click'
+  bugs:
+  - 1659241
+- note: '"Select All" (Ctrl+A) in message source did not work until focused with a mouse
+    click'
   tag: fixed
-  bug: 1657619
+  bugs:
+  - 1657619
 - note: 'Ctrl+scroll wheel not zooming in message reader'
   tag: fixed
-  bug: 1655244
+  bugs:
+  - 1655244
 - note: 'Setting/changing a signature from a file lost when closing account settings'
   tag: fixed
-  bug: 1657050
+  bugs:
+  - 1657050
 - note: 'Adaptive Junk Mail settings could not be disabled'
   tag: fixed
-  bug: 1646529
+  bugs:
+  - 1646529
 - note: 'Message filter dialog fixes: Missing scrollbar, drop-down list not wide enough'
   tag: fixed
-  bug: 1633306
-  bug2: 1656648
+  bugs:
+  - 1633306
+  - 1656648
 - note: 'Various UX and theme improvements'
   tag: fixed
-  bug: 656113
-  bug2: 1655289
-  bug3: 1655568
-  bug4: 1655573
+  bugs:
+  - 656113
+  - 1655289
+  - 1655568
+  - 1655573
 

--- a/release/78.2.1.yml
+++ b/release/78.2.1.yml
@@ -21,16 +21,20 @@ release:
 notes:
 - note: 'OpenPGP enabled by default'
   tag: changed
-  bug: 1659536
+  bugs:
+  - 1659536
 - note: 'OpenPGP: Disabled the use of MD5/SM2/SM3 algorithms'
   tag: changed
-  bug: 1641720
+  bugs:
+  - 1641720
 
-- note: 'OpenPGP: Users with sub-identities were unable to encrypt or sign messages
-  when switching identities'
+- note: 'OpenPGP: Users with sub-identities were unable to encrypt or sign messages when
+    switching identities'
   tag: fixed
-  bug: 1661160
+  bugs:
+  - 1661160
 - note: 'OpenPGP message security window did not support dark mode'
   tag: fixed
-  bug: 1661203
+  bugs:
+  - 1661203
 

--- a/release/78.2.2.yml
+++ b/release/78.2.2.yml
@@ -15,69 +15,87 @@ release:
 notes:
 - note: Drag and Drop reordering of recipient pills now supported
   tag: new
-  bug: 1601749
+  bugs:
+  - 1601749
 
 - note: 'OpenPGP: Some signature states reported as "mismatch" now report "unknown"'
   tag: changed
-  bug: 1662881
+  bugs:
+  - 1662881
 - note: Privacy policy now displayed in a tab when updated
   tag: changed
-  bug: 1651298
+  bugs:
+  - 1651298
 - note: 'Chat: Non-functional Twitter support removed'
   tag: changed
-  bug: 1445778
+  bugs:
+  - 1445778
 
 - note: 'OpenPGP: Improvements to key importing when failures occur'
   tag: fixed
-  bug: 1663037
+  bugs:
+  - 1663037
 - note: 'OpenPGP: Decryption did not work with certain HTTP proxy configurations'
   tag: fixed
-  bug: 1661913
-- note: 'OpenPGP: "Discover keys online" option did not work when searching for an
-  email address'
+  bugs:
+  - 1661913
+- note: 'OpenPGP: "Discover keys online" option did not work when searching for an email
+    address'
   tag: fixed
-  bug: 1663157
+  bugs:
+  - 1663157
 
 - note: Email filters reported failure when moving a message to original folder
   tag: fixed
-  bug: 1653690
-- note: 'Message filters: Filters shown as enabled in configuration dialog were not
-  always enabled'
+  bugs:
+  - 1653690
+- note: 'Message filters: Filters shown as enabled in configuration dialog were not always
+    enabled'
   tag: fixed
-  bug: 1660917
+  bugs:
+  - 1660917
 - note: vCard 2.1 attachments not handled properly
   tag: fixed
-  bug: 1659323
-  bug2: 1660134
+  bugs:
+  - 1659323
+  - 1660134
 - note: Sending messages sometimes failed when recipients were in LDAP address book
   tag: fixed
-  bug: 1371309
+  bugs:
+  - 1371309
 - note: Non-functional help menu items removed
   tag: fixed
-  bug: 1659318
-- note: 'Adding custom headers in the addressing widget (preference
-    mail.compose.other.header) did not work'
+  bugs:
+  - 1659318
+- note: 'Adding custom headers in the addressing widget (preference mail.compose.other.header)
+    did not work'
   tag: fixed
-  bug: 1658890
+  bugs:
+  - 1658890
 - note: 'Calendar: Event reminder details were unreadable'
   tag: fixed
-  bug: 1658923
+  bugs:
+  - 1658923
 - note: Windows 10 high-contrast theme fixes
   tag: fixed
-  bug: 1661229
+  bugs:
+  - 1661229
 - note: More theme fixes and improvements
   tag: fixed
-  bug: 1659380
-  bug2: 1662536
-  bug3: 1662585
-  bug4: 1662831
+  bugs:
+  - 1659380
+  - 1662536
+  - 1662585
+  - 1662831
 
 
 # Unresolved
-- note: 'Selecting "Cancel" on the Master Password prompt at startup incorrectly
-         reports corrupted OpenPGP data.'
+- note: 'Selecting "Cancel" on the Master Password prompt at startup incorrectly reports
+    corrupted OpenPGP data.'
   tag: unresolved
-  bug: 1664022
+  bugs:
+  - 1664022
 - note: 'Message list is not focused at startup'
   tag: unresolved
-  bug: 1620310
+  bugs:
+  - 1620310

--- a/release/78.3.0.yml
+++ b/release/78.3.0.yml
@@ -18,53 +18,66 @@ release:
 notes:
 - note: 'OpenPGP: Improved decryption performance with large messages'
   tag: changed
-  bug: 1659433
+  bugs:
+  - 1659433
 - note: 'OpenPGP: Do not show external key UI when disabled by preference'
   tag: changed
-  bug: 1657111
-- note: 'Account setup wizard will now open a popup when connecting to a server
-    with a self-signed SSL/TLS certificate'
+  bugs:
+  - 1657111
+- note: 'Account setup wizard will now open a popup when connecting to a server with a
+    self-signed SSL/TLS certificate'
   tag: changed
-  bug: 1590473
+  bugs:
+  - 1590473
 - note: 'Installation of "legacy" MailExtensions now disabled'
   tag: changed
-  bug: 1661216
+  bugs:
+  - 1661216
 - note: 'Reply-To header moved in compose window; now appears under From header'
   tag: changed
-  bug: 1653814
+  bugs:
+  - 1653814
 - note: 'Calendar: Sidebar UI improvements'
   tag: changed
-  bug: 1621135
+  bugs:
+  - 1621135
 
-- note: 'Selecting "Cancel" on the Master Password prompt at startup incorrectly
-         reported corrupted OpenPGP data'
+- note: 'Selecting "Cancel" on the Master Password prompt at startup incorrectly reported
+    corrupted OpenPGP data'
   tag: fixed
-  bug: 1664022
+  bugs:
+  - 1664022
 - note: 'OpenPGP: Creating a new key pair did not automatically select it for use'
   tag: fixed
-  bug: 1663422
-- note: 'Dragging & Dropping recipient pills resulted in lost pills when an error was
-    present'
+  bugs:
+  - 1663422
+- note: 'Dragging & Dropping recipient pills resulted in lost pills when an error was present'
   tag: fixed
-  bug: 1663041
+  bugs:
+  - 1663041
 - note: 'Spellcheck suggestions were unreadable in dark theme'
   tag: fixed
-  bug: 1663223
+  bugs:
+  - 1663223
 - note: 'Calendar: Multiple password prompts opened'
   tag: fixed
-  bug: 1664016
+  bugs:
+  - 1664016
 - note: 'Linux Distributions: UI was not rendered completely when built without updater'
   tag: fixed
-  bug: 1664607
-  bug2: 1664721
+  bugs:
+  - 1664607
+  - 1664721
 - note: 'MailExtensions: browser.folders.delete failed on IMAP folders'
   tag: fixed
-  bug: 1651308
+  bugs:
+  - 1651308
 
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.3">security fixes</a>
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.3">security
+    fixes</a>
   tag: fixed
 
 - note: 'Message list is not focused at startup'
   tag: unresolved
-  bug: 1620310
+  bugs:
+  - 1620310

--- a/release/78.3.1.yml
+++ b/release/78.3.1.yml
@@ -19,4 +19,5 @@ release:
 notes:
 - note: 'Thunderbird crashed after updating to 78.3.0'
   tag: fixed
-  bug: 1667120
+  bugs:
+  - 1667120

--- a/release/78.3.2.yml
+++ b/release/78.3.2.yml
@@ -13,34 +13,42 @@ release:
   import_system_requirements: '78.0'
 
 notes:
-- note: Thunderbird will no longer automatically install updates when Preferences
-    tab is opened
+- note: Thunderbird will no longer automatically install updates when Preferences tab is
+    opened
   tag: changed
-  bug: 1666324
+  bugs:
+  - 1666324
 - note: 'OpenPGP: Improved support for encrypting with subkeys'
   tag: fixed
-  bug: 1665281
-- note: 'OpenPGP: Encrypted messages with international characters were sometimes
-    displayed incorrectly'
+  bugs:
+  - 1665281
+- note: 'OpenPGP: Encrypted messages with international characters were sometimes displayed
+    incorrectly'
   tag: fixed
-  bug: 1665287
+  bugs:
+  - 1665287
 - note: Single-click deletion of recipient pills with middle mouse button restored
   tag: fixed
-  bug: 1661438
+  bugs:
+  - 1661438
 - note: Searching an address book list did not display results
   tag: fixed
-  bug: 1663935
+  bugs:
+  - 1663935
 - note: Windows installer was unreadable with Windows in high contrast mode
   tag: fixed
-  bug: 1665321
+  bugs:
+  - 1665321
 - note: Dark mode, high contrast, and Windows theming fixes
   tag: fixed
-  bug: 1665336
-  bug2: 1667109
-  bug3: 1667317
-  bug4: 1661229
+  bugs:
+  - 1665336
+  - 1667109
+  - 1667317
+  - 1661229
 
 
 - note: 'Message list is not focused at startup'
   tag: unresolved
-  bug: 1620310
+  bugs:
+  - 1620310

--- a/release/78.3.3.yml
+++ b/release/78.3.3.yml
@@ -15,17 +15,22 @@ release:
 notes:
 - note: 'OpenPGP: Improved support for encrypting with subkeys'
   tag: fixed
-  bug: 1665497
+  bugs:
+  - 1665497
 - note: 'OpenPGP message status icons were not visible in message header pane'
   tag: fixed
-  bug: 1670067
+  bugs:
+  - 1670067
 - note: OpenPGP Key Manager was missing from Tools menu on macOS
   tag: fixed
-  bug: 1662279
+  bugs:
+  - 1662279
 - note: Creating a new calendar event did not require an event title
   tag: fixed
-  bug: 1663303
+  bugs:
+  - 1663303
 
 - note: 'Message list is not focused at startup'
   tag: unresolved
-  bug: 1620310
+  bugs:
+  - 1620310

--- a/release/78.4.0.yml
+++ b/release/78.4.0.yml
@@ -15,58 +15,68 @@ release:
 notes:
 - note: 'MailExtensions: browser.tabs.sendMessage API added'
   tag: new
-  bug: 1641576
+  bugs:
+  - 1641576
 - note: 'MailExtensions: messageDisplayScripts API added'
   tag: new
-  bug: 1504475
+  bugs:
+  - 1504475
 
 - note: Yahoo and AOL mail users using password authentication will be migrated to OAuth2
   tag: changed
-  bug: 1606339
-  bug2: 1670892
-- note: 'MailExtensions: messageDisplay APIs extended to support multiple selected
-    messages'
+  bugs:
+  - 1606339
+  - 1670892
+- note: 'MailExtensions: messageDisplay APIs extended to support multiple selected messages'
   tag: changed
-  bug: 1617461
-- note: 'MailExtensions: compose.begin functions now support creating a message with
-    attachments'
+  bugs:
+  - 1617461
+- note: 'MailExtensions: compose.begin functions now support creating a message with attachments'
   tag: changed
-  bug: 1662018
+  bugs:
+  - 1662018
 
 
 - note: Thunderbird could freeze when updating global search index
   tag: fixed
-  bug: 1669872
+  bugs:
+  - 1669872
 - note: Multiple issues with handling of self-signed SSL certificates addressed
   tag: fixed
-  bug: 1590474
-  bug2: 1665577
-  bug3: 1667043
+  bugs:
+  - 1590474
+  - 1665577
+  - 1667043
 - note: Recipient address fields in compose window could expand to fill all available space
   tag: fixed
-  bug: 1666463
-  bug2: 1667173
-  bug3: 1667602
+  bugs:
+  - 1666463
+  - 1667173
+  - 1667602
 - note: Inserting emoji characters in message compose window caused unexpected behavior
   tag: fixed
-  bug: 1638874
-  bug2: 1665174
+  bugs:
+  - 1638874
+  - 1665174
 - note: Button to restore default folder icon color was not keyboard accessible
   tag: fixed
-  bug: 1663075
+  bugs:
+  - 1663075
 - note: Various keyboard navigation fixes
   tag: fixed
-  bug: 1667567
-  bug2: 1667614
+  bugs:
+  - 1667567
+  - 1667614
 - note: Various color-related theme fixes
   tag: fixed
-  bug: 1668410
-  bug2: 1668896
-- note: 'MailExtensions: Updating attachments with onBeforeSend.addListener() did
-    not work'
+  bugs:
+  - 1668410
+  - 1668896
+- note: 'MailExtensions: Updating attachments with onBeforeSend.addListener() did not work'
   tag: fixed
-  bug: 1662015
+  bugs:
+  - 1662015
 
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.4">security fixes</a>
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.4">security
+    fixes</a>
   tag: fixed

--- a/release/78.4.1.yml
+++ b/release/78.4.1.yml
@@ -16,39 +16,49 @@ notes:
 - note: Thunderbird prompts for an address to use when starting an email from an address
     book entry with multiple addresses
   tag: new
-  bug: 84028
+  bugs:
+  - 84028
 
 - note: Searching global search results did not work
   tag: fixed
-  bug: 1664761
-- note: Link location was not focused by default when adding a hyperlink in message
-    composer
+  bugs:
+  - 1664761
+- note: Link location was not focused by default when adding a hyperlink in message composer
   tag: fixed
-  bug: 1670660
+  bugs:
+  - 1670660
 - note: Advanced address book search dialog was unusable
   tag: fixed
-  bug: 1668147
+  bugs:
+  - 1668147
 - note: Encrypted draft reply emails lost "Re:" prefix
   tag: fixed
-  bug: 1661510
+  bugs:
+  - 1661510
 - note: Replying to a newsgroup message did not open the compose window
   tag: fixed
-  bug: 1672667
+  bugs:
+  - 1672667
 - note: Unable to delete multiple newsgroup messages
   tag: fixed
-  bug: 1657988
+  bugs:
+  - 1657988
 - note: Appmenu displayed visual glitches
   tag: fixed
-  bug: 1636243
+  bugs:
+  - 1636243
 - note: Visual glitches when selecting multiple messages in the message pane and using
     Ctrl+click
   tag: fixed
-  bug: 1671800
+  bugs:
+  - 1671800
 - note: Switching between dark and light mode could lead to unreadable text on macOS
   tag: fixed
-  bug: 1668989
+  bugs:
+  - 1668989
 
 
 - note: 'Message list is not focused at startup'
   tag: unresolved
-  bug: 1620310
+  bugs:
+  - 1620310

--- a/release/78.4.3.yml
+++ b/release/78.4.3.yml
@@ -13,13 +13,18 @@ release:
   import_system_requirements: '78.0'
 
 notes:
-- note: User interface was inconsistent when switching from the default theme to the dark theme and back to the default theme
+- note: User interface was inconsistent when switching from the default theme to the dark
+    theme and back to the default theme
   tag: fixed
-  bug: 1659282
-- note: Email subject would disappear when hovering over it with the mouse when using Windows 7 Classic theme
+  bugs:
+  - 1659282
+- note: Email subject would disappear when hovering over it with the mouse when using Windows
+    7 Classic theme
   tag: fixed
-  bug: 1675970
+  bugs:
+  - 1675970
 
 - note: 'Message list is not focused at startup'
   tag: unresolved
-  bug: 1620310
+  bugs:
+  - 1620310

--- a/release/78.5.0.yml
+++ b/release/78.5.0.yml
@@ -15,34 +15,42 @@ release:
 notes:
 - note: 'OpenPGP: Added option to disable attaching the public key to a signed message'
   tag: new
-  bug: 1654950
+  bugs:
+  - 1654950
 - note: 'MailExtensions: "compose_attachments" context added to Menus API'
   tag: new
-  bug: 1670822
+  bugs:
+  - 1670822
 - note: 'MailExtensions: Menus API now available on displayed messages'
   tag: new
-  bug: 1670825
+  bugs:
+  - 1670825
 
 - note: 'MailExtensions: browser.tabs.create will now wait for "mail-delayed-startup-finished"
     event'
   tag: changed
-  bug: 1674407
+  bugs:
+  - 1674407
 
 - note: 'OpenPGP: Support for inline PGP messages improved'
   tag: fixed
-  bug: 1672851
+  bugs:
+  - 1672851
 - note: 'OpenPGP: Message security dialog showed unverified keys as unavailable'
   tag: fixed
-  bug: 1675285
+  bugs:
+  - 1675285
 - note: 'Chat: New chat contact menu item did not function'
   tag: fixed
-  bug: 1663321
+  bugs:
+  - 1663321
 - note: Various theme and usability improvements
   tag: fixed
-  bug: 1673861
-  bug2: 1674606
-  bug3: 1676041
+  bugs:
+  - 1673861
+  - 1674606
+  - 1676041
 
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.5">security fixes</a>
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.5">security
+    fixes</a>
   tag: fixed

--- a/release/78.5.1.yml
+++ b/release/78.5.1.yml
@@ -15,54 +15,68 @@ release:
 notes:
 - note: 'OpenPGP: Added option to disable email subject encryption'
   tag: new
-  bug: 1666073
+  bugs:
+  - 1666073
 
-- note: OpenPGP public key import now supports multi-file selection and bulk accepting imported keys
+- note: OpenPGP public key import now supports multi-file selection and bulk accepting
+    imported keys
   tag: changed
-  bug: 1665145
-  bug2: 1675342
+  bugs:
+  - 1665145
+  - 1675342
 - note: 'MailExtensions: getComposeDetails will wait for "compose-editor-ready" event'
   tag: changed
-  bug: 1675012
+  bugs:
+  - 1675012
 
 - note: New mail icon was not removed from the system tray at shutdown
   tag: fixed
-  bug: 1664586
-- note: '"Place replies in the folder of the message being replied to" did not work
-    when using "Reply to List"'
+  bugs:
+  - 1664586
+- note: '"Place replies in the folder of the message being replied to" did not work when
+    using "Reply to List"'
   tag: fixed
-  bug: 522450
+  bugs:
+  - 522450
 - note: 'Thunderbird did not honor the "Run search on server" option when searching messages'
   tag: fixed
-  bug: 546925
+  bugs:
+  - 546925
 - note: Highlight color for folders with unread messages wasn't visible in dark theme
   tag: fixed
-  bug: 1676697
-  bug2: 1678029
+  bugs:
+  - 1676697
+  - 1678029
 - note: 'OpenPGP: Key were missing from Key Manager'
   tag: fixed
-  bug: 1674521
+  bugs:
+  - 1674521
 - note: 'OpenPGP: Option to import keys from clipboard always disabled'
   tag: fixed
-  bug: 1676842
+  bugs:
+  - 1676842
 - note: The "Link" button on the large attachments info bar failed to open up Filelink
     section in Options if the user had not yet configured Filelink
   tag: fixed
-  bug: 1677647
+  bugs:
+  - 1677647
 - note: 'Address book: Printing members of a mailing list resulted in incorrect output'
   tag: fixed
-  bug: 1676859
+  bugs:
+  - 1676859
 - note: 'Unable to connect to LDAP servers configured with a self-signed SSL certificate'
   tag: fixed
-  bug: 1659947
+  bugs:
+  - 1659947
 - note: Autoconfig via LDAP did not work as expected
   tag: fixed
-  bug: 1662433
-- note: 'Calendar: Pressing Ctrl-Enter in the new event dialog would create duplicate
-    events'
+  bugs:
+  - 1662433
+- note: 'Calendar: Pressing Ctrl-Enter in the new event dialog would create duplicate events'
   tag: fixed
-  bug: 1668478
+  bugs:
+  - 1668478
 
-- note: Various
-    <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.5.1">security fixes</a>
+- note: Various <a href="https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.5.1">security
+    fixes</a>
   tag: fixed

--- a/release/78.6.0.yml
+++ b/release/78.6.0.yml
@@ -15,75 +15,95 @@ release:
 notes:
 - note: 'MailExtensions: Added browser.windows.openDefaultBrowser()'
   tag: new
-  bug: 1664708
+  bugs:
+  - 1664708
 
 - note: Thunderbird now only shows quota exceeded indications on the main window
   tag: changed
-  bug: 1671748
+  bugs:
+  - 1671748
 - note: 'MailExtensions: menus API enabled in messages being composed'
   tag: changed
-  bug: 1670832
-- note: 'MailExtensions: Honor allowScriptsToClose argument in windows.create API
-  function'
+  bugs:
+  - 1670832
+- note: 'MailExtensions: Honor allowScriptsToClose argument in windows.create API function'
   tag: changed
-  bug: 1675940
-- note: 'MailExtensions: APIs that returned an accountId will reflect the account
-  the message belongs to, not what is stored in message headers'
+  bugs:
+  - 1675940
+- note: 'MailExtensions: APIs that returned an accountId will reflect the account the message
+    belongs to, not what is stored in message headers'
   tag: changed
-  bug: 1644032
+  bugs:
+  - 1644032
 
 - note: Keyboard shortcut for toggling message "read" status not shown in menus
   tag: fixed
-  bug: 1619248
-- note: 'OpenPGP: After importing a secret key, Key Manager displayed properties of
-  the wrong key'
+  bugs:
+  - 1619248
+- note: 'OpenPGP: After importing a secret key, Key Manager displayed properties of the
+    wrong key'
   tag: fixed
-  bug: 1667054
+  bugs:
+  - 1667054
 - note: 'OpenPGP: Inline PGP parsing improvements'
   tag: fixed
-  bug: 1660041
+  bugs:
+  - 1660041
 - note: 'OpenPGP: Discovering keys online via Key Manager sometimes failed on Linux'
   tag: fixed
-  bug: 1634053
+  bugs:
+  - 1634053
 - note: 'OpenPGP: Encrypted attachment "Decrypt and Open/Save As" did not work'
   tag: fixed
-  bug: 1663169
+  bugs:
+  - 1663169
 - note: 'OpenPGP: Importing keys failed on macOS'
   tag: fixed
-  bug: 1680757
+  bugs:
+  - 1680757
 - note: 'OpenPGP: Verification of clear signed UTF-8 text failed'
   tag: fixed
-  bug: 1679756
+  bugs:
+  - 1679756
 - note: 'Address book: Some columns incorrectly displayed no data'
   tag: fixed
-  bug: 1631201
-- note: 'Address book: The address book view did not update after changing the name
-  format in the menu'
+  bugs:
+  - 1631201
+- note: 'Address book: The address book view did not update after changing the name format
+    in the menu'
   tag: fixed
-  bug: 1678555
+  bugs:
+  - 1678555
 - note: 'Calendar: Could not import an ICS file into a CalDAV calendar'
   tag: fixed
-  bug: 1652984
+  bugs:
+  - 1652984
 - note: 'Calendar: Two "Home" calendars were visible on a new profile'
   tag: fixed
-  bug: 1656782
+  bugs:
+  - 1656782
 - note: 'Calendar: Dark theme was incomplete on Linux'
   tag: fixed
-  bug: 1655543
+  bugs:
+  - 1655543
 - note: 'Dark theme did not apply to new mail notification popups'
   tag: fixed
-  bug: 1681083
+  bugs:
+  - 1681083
 - note: 'Folder icon, message list, and contact side bar visual improvements'
   tag: fixed
-  bug: 1679436
-  bug2: 1680432
-  bug3: 1680947
+  bugs:
+  - 1679436
+  - 1680432
+  - 1680947
 - note: 'MailExtensions: HTTP refresh in browser content tabs did not work'
   tag: fixed
-  bug: 1667774
+  bugs:
+  - 1667774
 - note: 'MailExtensions: messageDisplayScripts failed to run in main window'
   tag: fixed
-  bug: 1674932
+  bugs:
+  - 1674932
 
 - note: Various [security fixes](https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.6)
   tag: fixed
@@ -91,4 +111,5 @@ notes:
 
 - note: 'Thunderbird performs sluggishly on macOS Big Sur'
   tag: unresolved
-  bug: 1677272
+  bugs:
+  - 1677272

--- a/release/78.6.1.yml
+++ b/release/78.6.1.yml
@@ -16,57 +16,72 @@ notes:
 - note: 'MailExtensions: browserAction, composeAction, and messageDisplayAction toolbar
     buttons now support label and default_label properties'
   tag: changed
-  bug: 1583478
+  bugs:
+  - 1583478
 
-- note: 'Running a quicksearch that returned no results did not offer to re-run as a global search'
+- note: 'Running a quicksearch that returned no results did not offer to re-run as a global
+    search'
   tag: fixed
-  bug: 1663153
+  bugs:
+  - 1663153
 - note: Message search toolbar fixes
   tag: fixed
-  bug: 1681010
-- note: Very long subject lines distorted the message compose and display windows,
-    making them unusable
+  bugs:
+  - 1681010
+- note: Very long subject lines distorted the message compose and display windows, making
+    them unusable
   tag: fixed
-  bug: 77806
-  bug2: 1682023
-- note: 'Compose window: Recipient addresses that had not yet been autocompleted were
-  lost when clicking Send button'
+  bugs:
+  - 77806
+  - 1682023
+- note: 'Compose window: Recipient addresses that had not yet been autocompleted were lost
+    when clicking Send button'
   tag: fixed
-  bug: 1674054
-  bug2: 1679848
-  bug3: 1681389
+  bugs:
+  - 1674054
+  - 1679848
+  - 1681389
 - note: 'Compose window: New message is no longer marked as "changed" just from tabbing
-  out of the recipient field without editing anything'
+    out of the recipient field without editing anything'
   tag: fixed
-  bug: 1681389
+  bugs:
+  - 1681389
 - note: 'Account autodiscover fixes when using MS Exchange servers'
   tag: fixed
-  bug: 1679759
-  bug2: 1682890
+  bugs:
+  - 1679759
+  - 1682890
 - note: LDAP address book stability fix
   tag: fixed
-  bug: 1680914
-- note: Messages with invalid vcard attachments were not marked as read when viewed
-    in the preview window
+  bugs:
+  - 1680914
+- note: Messages with invalid vcard attachments were not marked as read when viewed in
+    the preview window
   tag: fixed
-  bug: 1680468
+  bugs:
+  - 1680468
 - note: 'Chat: Could not add TLS certificate exceptions for XMPP connections'
   tag: fixed
-  bug: 1590471
+  bugs:
+  - 1590471
 - note: 'Calendar: System timezone was not always properly detected'
   tag: fixed
-  bug: 1678839
-- note: 'Calendar: Descriptions were sometimes blank when editing a single occurrence
-  of a repeating event'
+  bugs:
+  - 1678839
+- note: 'Calendar: Descriptions were sometimes blank when editing a single occurrence of
+    a repeating event'
   tag: fixed
-  bug: 1664731
+  bugs:
+  - 1664731
 - note: Various printing bugfixes
   tag: fixed
-  bug: 1676166
+  bugs:
+  - 1676166
 - note: Visual consistency and theme improvements
   tag: fixed
-  bug: 1682808
-  bug2: 1682971
+  bugs:
+  - 1682808
+  - 1682971
 
 - note: Various [security fixes](https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.6.1)
   tag: fixed

--- a/release/78.7.0.yml
+++ b/release/78.7.0.yml
@@ -13,57 +13,84 @@ release:
   import_system_requirements: '78.0'
 
 notes:
-- note: 'Extension API: Compose API now supports editing messages and templates as new messages'
+- note: 'Extension API: Compose API now supports editing messages and templates as new
+    messages'
   tag: new
-  bug: 1670379
+  bugs:
+  - 1670379
 - note: 'Extension API: composeHtml is now exposed in MailIdentity'
   tag: new
-  bug: 1617377
+  bugs:
+  - 1617377
 - note: 'Extension API: windows.update and windows.create now support titlePreface'
   tag: new
-  bug: 1647768
+  bugs:
+  - 1647768
 - note: 'Extension API: new Accounts API functions: accounts.getDefault() and accounts.getDefaultIdentity(accountId)'
   tag: new
-  bug: 1681141
+  bugs:
+  - 1681141
 
-- note: 'Extension API: body and plainTextBody are now used as compose mode selectors in setComposeDetails and begin* functions in Compose API'
+- note: 'Extension API: body and plainTextBody are now used as compose mode selectors in
+    setComposeDetails and begin* functions in Compose API'
   tag: changed
-  bug: 1681023
-- note: 'Theme: removed the double border around the task description field on the Tasks tab'
+  bugs:
+  - 1681023
+- note: 'Theme: removed the double border around the task description field on the Tasks
+    tab'
   tag: changed
-  bug: 1684381
+  bugs:
+  - 1684381
 
-- note: 'Account Manager: When deleting the last remaining account, the default account was not getting cleared and still pointed to the no-longer-existing account'
+- note: 'Account Manager: When deleting the last remaining account, the default account
+    was not getting cleared and still pointed to the no-longer-existing account'
   tag: fixed
-  bug: 1680653
-- note: 'OpenPGP: Verification of an inline signed message would fail if it contained leading whitespace'
+  bugs:
+  - 1680653
+- note: 'OpenPGP: Verification of an inline signed message would fail if it contained leading
+    whitespace'
   tag: fixed
-  bug: 1679769
+  bugs:
+  - 1679769
 - note: 'OpenPGP: Various other minor bug and stability fixes'
   tag: fixed
-  bug: 1675325
-  bug2: 1677508
-- note: 'Mail Window: Quickfilter bar buttons disappear when hovered on Windows 10 High Contrast Black theme'
+  bugs:
+  - 1675325
+  - 1677508
+- note: 'Mail Window: Quickfilter bar buttons disappear when hovered on Windows 10 High
+    Contrast Black theme'
   tag: fixed
-  bug: 1676911
-- note: 'Theme: folder properties dialog contained black text on a black background in dark mode'
+  bugs:
+  - 1676911
+- note: 'Theme: folder properties dialog contained black text on a black background in
+    dark mode'
   tag: fixed
-  bug: 1684949
-- note: 'Theme: recipient pills in compose window were not visible in high contrast dark theme on Windows 10'
+  bugs:
+  - 1684949
+- note: 'Theme: recipient pills in compose window were not visible in high contrast dark
+    theme on Windows 10'
   tag: fixed
-  bug: 1676910
-- note: 'Extension API: browserAction buttons were not restored after restart if they were moved outside the default toolbar'
+  bugs:
+  - 1676910
+- note: 'Extension API: browserAction buttons were not restored after restart if they were
+    moved outside the default toolbar'
   tag: fixed
-  bug: 1598190
-- note: 'Extension API: browser.compose.beginNew could not override identity plaintext setting'
+  bugs:
+  - 1598190
+- note: 'Extension API: browser.compose.beginNew could not override identity plaintext
+    setting'
   tag: fixed
-  bug: 1658132
+  bugs:
+  - 1658132
 - note: 'Extension API: browser.compose.beginForward was ignoring ComposeDetails'
   tag: fixed
-  bug: 1658657
-- note: 'Extension API: browser.compose.setComposeDetails did not properly handle Windows-style line endings'
+  bugs:
+  - 1658657
+- note: 'Extension API: browser.compose.setComposeDetails did not properly handle Windows-style
+    line endings'
   tag: fixed
-  bug: 1672407
+  bugs:
+  - 1672407
 
 - note: Various [security fixes](https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.7)
   tag: fixed
@@ -71,4 +98,5 @@ notes:
 
 - note: 'Thunderbird performs sluggishly on macOS Big Sur'
   tag: unresolved
-  bug: 1677272
+  bugs:
+  - 1677272

--- a/release/78.7.1.yml
+++ b/release/78.7.1.yml
@@ -15,25 +15,32 @@ release:
 notes:
 - note: CardDAV address books now support OAuth2 and Google Contacts.
   tag: new
-  bug: 1662979
+  bugs:
+  - 1662979
 - note: Thunderbird will no longer allow installation of addons that use the legacy API
   tag: changed
-  bug: 1688904
+  bugs:
+  - 1688904
 - note: Send message button sometimes remained enabled when it should be disabled
   tag: fixed
-  bug: 1687431
+  bugs:
+  - 1687431
 - note: Pressing command+enter to send a message on macOS did not work
   tag: fixed
-  bug: 1682147
+  bugs:
+  - 1682147
 - note: 'OpenPGP: Failed to save attachments that contained binary data after decryption'
   tag: fixed
-  bug: 1686055
+  bugs:
+  - 1686055
 - note: Global search UI fixes
   tag: fixed
-  bug: 1578302
-  bug2: 1687034
+  bugs:
+  - 1578302
+  - 1687034
 - note: Various theme and color fixes to improve ease of use
   tag: fixed
-  bug: 1688034
-  bug2: 1688758
-  bug3: 1689509
+  bugs:
+  - 1688034
+  - 1688758
+  - 1689509

--- a/release/78.8.0.yml
+++ b/release/78.8.0.yml
@@ -13,31 +13,38 @@ release:
   import_system_requirements: '78.0'
 
 notes:
-  - note: Importing an address book from a CSV file always reported an error
-    tag: fixed
-    bug: 1685048
+- note: Importing an address book from a CSV file always reported an error
+  tag: fixed
+  bugs:
+  - 1685048
 
-  - note: Security information for S/MIME messages was not displayed correctly prior
-      to a draft being saved
-    tag: fixed
-    bug: 1683701
-  - note: 'Calendar: FileLink UI fixes for Caldav calendars'
-    tag: fixed
-    bug: 1669803
-  - note: Recurring tasks were always marked incomplete; unable to use filters
-    tag: fixed
-    bug: 1686466
-  - note: Various UI widgets not working
-    tag: fixed
-    bug: 1690098
-    bug2: 1690514
-  - note: Dark theme improvements
-    tag: fixed
-    bug: 1691106
-    bug2: 1691787
-  - note: Extension manager was missing link to addon support web page
-    tag: fixed
-    bug: 1642219
+- note: Security information for S/MIME messages was not displayed correctly prior to a
+    draft being saved
+  tag: fixed
+  bugs:
+  - 1683701
+- note: 'Calendar: FileLink UI fixes for Caldav calendars'
+  tag: fixed
+  bugs:
+  - 1669803
+- note: Recurring tasks were always marked incomplete; unable to use filters
+  tag: fixed
+  bugs:
+  - 1686466
+- note: Various UI widgets not working
+  tag: fixed
+  bugs:
+  - 1690098
+  - 1690514
+- note: Dark theme improvements
+  tag: fixed
+  bugs:
+  - 1691106
+  - 1691787
+- note: Extension manager was missing link to addon support web page
+  tag: fixed
+  bugs:
+  - 1642219
 
-  - note: Various [security fixes](https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.8)
-    tag: fixed
+- note: Various [security fixes](https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird78.8)
+  tag: fixed

--- a/template/release-notes.html
+++ b/template/release-notes.html
@@ -39,14 +39,14 @@
           </li>
         {% endif %}
         {% if ns.changes %}
-        <li class="ml-2 mr-2">
-          <a href="#changes" class="btn-link">{{ _('Changes') }}</a>
-        </li>
+          <li class="ml-2 mr-2">
+            <a href="#changes" class="btn-link">{{ _('Changes') }}</a>
+          </li>
         {% endif %}
         {% if ns.fixes %}
-        <li class="ml-2 mr-2">
-          <a href="#fixes" class="btn-link">{{ _('Bug Fixes') }}</a>
-        </li>
+          <li class="ml-2 mr-2">
+            <a href="#fixes" class="btn-link">{{ _('Bug Fixes') }}</a>
+          </li>
         {% endif %}
         <li class="ml-2 mr-2">
           <a href="{{ url('thunderbird.releases.index') }}" class="btn-link">{{ _('All Releases') }}</a>
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block content %}
-  <section  class="pt-20 flex justify-center items-center pl-8 pr-8">
+  <section class="pt-20 flex justify-center items-center pl-8 pr-8">
     <aside class="flex flex-col w-full max-w-6xl lg:ml-16 lg:mr-16">
       <p class="font-lg tracking-wider leading-loose mb-6 p-links-blue">
         {{ _('Check out the notes below for this version of Thunderbird. As always, you’re encouraged to <a href="%(feedback)s">tell us what you think</a>, or <a href="%(bugzilla)s">file a bug in Bugzilla</a>')|format(feedback='https://support.mozilla.org/questions/new/thunderbird', bugzilla='https://bugzilla.mozilla.org/') }}
@@ -94,15 +94,15 @@
             {% if note.get('group', 1)-1 == group and note.tag != 'unresolved' %}
               {% if note.tag == 'new' and section.name != note.tag %}
                 <h3 id="whatsnew" class="header-section">
-                  <span>{{ svg('bookmark') }}</span>{{ _('What’s New')}}
+                  <span>{{ svg('bookmark') }}</span>{{ _('What’s New') }}
                 </h3>
               {% elif note.tag == 'changed' and section.name != note.tag %}
                 <h3 id="changes" class="header-section pt-14 pb-4">
-                  <span>{{ svg('sync') }}</span>{{ _('Changes')}}
+                  <span>{{ svg('sync') }}</span>{{ _('Changes') }}
                 </h3>
               {% elif note.tag == 'fixed' and section.name != note.tag %}
                 <h3 id="fixes" class="header-section pt-14 pb-4">
-                  <span>{{ svg('check') }}</span>{{ _('Fixes')}}
+                  <span>{{ svg('check') }}</span>{{ _('Fixes') }}
                 </h3>
               {% endif %}
 
@@ -132,11 +132,11 @@
                 <aside class="flex-1 p-3 font-md leading-normal markup-page no-padding">
                   {{ note.note|markdown|safe }}
                 </aside>
-		{% if is_preview %}
-                <aside>
-                  {{ note.bug_links|markdown|safe }}
-                </aside>
-		{% endif %}
+                {% if is_preview %}
+                  <aside>
+                    {{ note.bug_links|markdown|safe }}
+                  </aside>
+                {% endif %}
               </aside>
             {% endif %}
           {% endfor %}
@@ -144,7 +144,7 @@
 
         {% if known_issues %}
           <h3 id="known-issues" class="header-section pt-14 pb-4">
-            <span>{{ svg('warning') }}</span>{{ _('Known Issues')}}
+            <span>{{ svg('warning') }}</span>{{ _('Known Issues') }}
           </h3>
           {% for note in known_issues %}
             <aside id="note-{{ note.id }}" class="flex flex-row flex-wrap items-center bg-white shadow-md mb-4 rounded">
@@ -164,11 +164,11 @@
                   </p>
                 {% endif %}
               </aside>
-	      {% if is_preview %}
-              <aside>
-                {{ note.bug_links|markdown|safe }}
-              </aside>
-	      {% endif %}
+                {% if is_preview %}
+                  <aside>
+                    {{ note.bug_links|markdown|safe }}
+                  </aside>
+                {% endif %}
             </aside>
           {% endfor %}
         {% endif %}

--- a/tools/bug_fixer.py
+++ b/tools/bug_fixer.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python3
+"""
+Updates the YAML files for each release replacing bug: bug2: bug3: etc
+with a list structure instead.
+
+This script was written for Python 3.9, though it should run on >= 3.6
+
+The only external requirement is ruamel.yaml==0.16.12
+ruamel.yaml was chosen over PyYAML as it has built in functionality to
+preserve comments and whitespace aka "round-trip" editing.
+
+Running:
+Run from root of a thunderbird-notes checkout. The script checks for a
+"new" directory in the root and will silently remove it if one exists.
+
+The existing YAML files are not modified by this script, the ["release",
+"beta", "archive"] structure is recreated under new/ and the output is
+written there. After verifying the output, the new files can be copied
+(not moved!) over the old files.
+
+```
+ cp -av new/* .
+```
+
+The new directory will not have every YAML file! There are several
+releases especially in archive that do not have any bug numbers. Those
+files are not written to new to make verification a little easier.
+
+Verification:
+I have not personally inspected every YAML file that this script outputs.
+I have checked about 25% of them. It's possible that some will be
+formatted oddly after being updated.
+
+I have run a website build with the modified files. That resulted in
+no changes to the rendered HTML.
+"""
+
+import os
+import shutil
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="rt")
+yaml.default_flow_style = False
+yaml.unicode_supplementary = False
+yaml.preserve_quotes = True
+yaml.width = 85
+
+
+def update_notes_file(path, new_path, notes_file):
+    changed_flag = False
+    if notes_file.endswith(".yml"):
+        notes_path = os.path.join(path, notes_file)
+        with open(notes_path, "r") as f:
+            doc = yaml.load(f)
+
+        for note in doc['notes']:
+            bugs = [int(bug) for k, bug in note.items() if k.startswith("bug")]
+            bug_keys = [k for k in note.keys() if k.startswith("bug")]
+
+            if bugs:
+                changed_flag = True
+
+                # To preserve formatting as much as possible, place the new list
+                # within the OrderedDict right before "bug".
+                bug_pos = list(note.keys()).index("bug")
+                note.insert(bug_pos, "bugs", yaml.seq(bugs))
+
+                # Move any comments associated with the bug number lines.
+                # This includes blank lines that may be present after
+                for bug_key in bug_keys:
+                    if bug_key in note.ca.items:
+                        # bug -> 0, bug2 -> 1, bug3 -> 2...
+                        if bug_key == "bug":
+                            bug_index = 0
+                        else:
+                            # This may produce a ValueError if there's any bad
+                            # YAML left.
+                            bug_index = int(bug_key[-1]) - 1
+
+                        # This is an internal ruamel.yaml comment structure.
+                        # It's mostly meant to grab any blank lines when the bug number(s)
+                        # are positioned last in the note structure within the YAML
+                        note["bugs"].ca.items[bug_index] = [note.ca.items[bug_key][2], None, None, None]
+
+                    # Remove the old bug bug2 bug3 keys, leaving bugs in the same place
+                    del note[bug_key]
+
+        if changed_flag:
+            new_file = os.path.join(new_path, notes_file)
+
+            with open(new_file, 'w') as fp:
+                yaml.dump(doc, fp)
+
+
+def main():
+    notes_dirs = [
+        'release',
+        'beta',
+        'archive',
+    ]
+
+    base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    new_notes_base = os.path.join(base_path, "new")
+    try:
+        shutil.rmtree(new_notes_base)
+    except FileNotFoundError:
+        pass
+    os.mkdir(new_notes_base)
+
+    for notes_dir in notes_dirs:
+        path = os.path.join(base_path, notes_dir)
+        new_path = os.path.join(new_notes_base, notes_dir)
+        os.mkdir(new_path)
+        notes_files = os.listdir(path)
+        for notes_file in notes_files:
+            update_notes_file(path, new_path, notes_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gather_notes.py
+++ b/tools/gather_notes.py
@@ -26,18 +26,11 @@ BUG_NUMBER_REGEX = re.compile(r'bug \d+', re.IGNORECASE)
 BACKOUT_REGEX = re.compile(r'back(\s?)out|backed out|backing out', re.IGNORECASE)
 
 
-class Bug:
-    def __init__(self, bug_no, tag, note_text):
-        self.bugs = [bug_no]
+class RelNote:
+    def __init__(self, bugs, tag, note_text):
+        self.bugs = bugs
         self.tag = tag
         self.note = note_text
-
-    def add_bug(self, bug):
-        self.bugs.append(bug)
-
-    def strip_bugs(self, fixed):
-        fixed_bugs = [bug_no for bug_no in self.bugs if bug_no in fixed]
-        self.bugs = fixed_bugs
 
 
 def represent_dictionary_order(self, dict_data):
@@ -95,16 +88,12 @@ def load_notes(previous_esr, this_beta):
     for ver_str in [str(v) for v in versions]:
         ver_notes = beta_notes[ver_str]['notes']
         for note in ver_notes:
-            if 'bug' not in note:
+            if 'bugs' not in note:
                 continue
             if note['tag'] == 'unresolved':
                 continue
 
-            rel_note = Bug(note['bug'], note['tag'], note['note'])
-
-            for b in ('bug2', 'bug3', 'bug4', 'bug5', 'bug6', 'bug7', 'bug8', 'bug9'):
-                if b in note:
-                    rel_note.add_bug(note[b])
+            rel_note = RelNote(note['bugs'], note['tag'], note['note'])
 
             new_notes.append(rel_note)
 


### PR DESCRIPTION
Here is everything except the converted YAML files. As noted in bug_fixer.py, I ran a website build with the converted files and had zero differences. The converted YAML files preserve whitespace and comments so that they are still readable by humans.