### PR TITLE
Update 115.4.1.yml

### DIFF
--- a/release/115.4.1.yml
+++ b/release/115.4.1.yml
@@ -21,7 +21,7 @@ notes:
     bugs: [1847428]
   
   # Fixed
-  - note: Manually configured authentication methods on accounts did no always persist
+  - note: Manually configured authentication methods on accounts did not always persist
     tag: fixed
     bugs: [1855515]
   - note: '"Send Autocrypt key in header" preference was available on accounts with no
@@ -87,7 +87,7 @@ notes:
   - note: OTR verification dialog was blank, preventing verification of OTR chat sessions
     tag: fixed
     bugs: [1852030]
-  - note: Calendar ICS parser improvements for more reliable event import
+  - note: Calendar event import failed for some ICS files
     tag: fixed
     bugs: [1857196]
   - note: 'Permission description strings were missing from Add-Ons Manager'


### PR DESCRIPTION
Fixed "no" typo.

I also tried to rewrite the summary for bug 1857196, as these lines are usually written to describe the problem that was fixed. So "Fixed: Calendar ICS parser improvements" makes it sound like "Calendar ICS parser improvements" was a problem that needed fixing!

I'm not sure my new wording is ideal, so feel free to modify it, but hopefully you get the gist of what I'm trying to do. Thanks :)